### PR TITLE
feat: add iam clone policy tool

### DIFF
--- a/docs/capability-gap-analysis.md
+++ b/docs/capability-gap-analysis.md
@@ -20,7 +20,7 @@ scope boundary is a deliberate, visible line rather than an implicit one.
 | API keys: create/list/delete | ✅ | ✅ | ✅ |
 | **API keys: update** (description/expiry without rotating the secret) | ✅ | ✅ (`UPDATE`) | ✅ **fixed 2026-08-18** (`scaleway_iam_update_api_key`) |
 | Policies: create/get/list/update/delete | ✅ | ✅ | ✅ |
-| Policies: **clone/duplicate** | ✅ (UI action) | ✅ | ❌ missing (achievable manually: `get` + re-`create`) - tracked in [#3](https://github.com/logic-arts-official/scaleway-ops-mcp-server/issues/3) |
+| Policies: **clone/duplicate** | ✅ (UI action) | ✅ | ✅ **fixed 2026-08-18** (`scaleway_iam_clone_policy`) - atomic copy of rules/principal/tags; name is duplicated so rename after if needed - tracked in [#3](https://github.com/logic-arts-official/scaleway-ops-mcp-server/issues/3) |
 | Policy rules: list/set (full-replace) | ✅ | ✅ | ✅ |
 | Permission sets: list | ✅ | ✅ | ✅ |
 | **Users** (human members): list/create/delete/update, lock/unlock, MFA, password/username | ✅ | ✅ | ❌ out of scope (this server manages Applications, i.e. non-human identities, only) - tracked in [#4](https://github.com/logic-arts-official/scaleway-ops-mcp-server/issues/4) |

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -150,6 +150,30 @@ itself fail `permissions_denied`, since the credential attempting it no longer h
 that call requires. `SetRules` has no such window: the policy object, and everything that already
 depends on its `id`, never stops existing.
 
+## `POST /policies/{id}/clone` ignores its request body and always returns the clone unattached
+
+Confirmed empirically 2026-08-18, reviewing `scaleway_iam_clone_policy`: the clone endpoint copies
+rules correctly but silently drops the principal and tags regardless of what's passed - the clone
+always comes back `no_principal: true` with `tags: []`, even when the request body explicitly
+includes `application_id`/`user_id`/`group_id`/`name` overrides (all silently ignored; the name gets
+Scaleway's own `"Copy of <source name>"` default, not an override). Worse than just a doc gap: since
+`scaleway_iam_update_policy` only patches `name`/`description`/`tags` (never a principal field),
+there was briefly no way to reattach a clone's principal through this server at all. Confirmed via a
+direct `PATCH /policies/{id}` call that Scaleway's API *does* accept and apply `application_id` -
+it's this server's tool schema that didn't expose it, not an API limitation. `clone_policy` now
+follows its `POST .../clone` with a `PATCH` restoring the source's principal and tags before
+returning, so the tool actually delivers an exact copy instead of an orphaned one.
+
+## `nb_rules`/`nb_permission_sets` can read 0 immediately after `create_policy` or `clone_policy`, even though the rules did apply
+
+Confirmed empirically 2026-08-18, live-retesting: the `Policy` object returned directly by
+`POST /policies` (and by extension `POST /policies/{id}/clone`) can report `nb_rules: 0` in that same
+response even though the rules were in fact created - a follow-up `scaleway_iam_get_policy` or
+`scaleway_iam_list_policy_rules` on the same policy immediately afterward shows the correct count and
+the actual rules. Looks like the count lags the write by a moment. Not a bug in this server (it
+passes Scaleway's response through as-is) - just don't read a `0` in a `create`/`clone` response as
+"the rules didn't take"; call `scaleway_iam_list_policy_rules` for ground truth if in doubt.
+
 ## Audit Trail needs its own permission set, and it's organization-scoped
 
 `scaleway_audit_list_events` needs `AuditTrailReadOnly` (or `OrganizationManager`) - not implied by

--- a/src/tools/policies.ts
+++ b/src/tools/policies.ts
@@ -85,6 +85,10 @@ const updateSchema = {
     ),
 };
 
+const cloneSchema = {
+  policy_id: z.string().uuid(),
+};
+
 const listSchema = {
   application_id: z.string().uuid().optional().describe("Filter to policies attached to one Application."),
 };
@@ -141,6 +145,28 @@ export function registerPolicies(server: McpServer, config: Config) {
           group_id,
           rules,
         });
+        return toolJsonResult(policy, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_iam_clone_policy",
+    {
+      title: "Clone Scaleway IAM Policy",
+      description:
+        "Clone an existing IAM Policy in one atomic call (the API's CLONE operation, the console's " +
+        "'Duplicate' action). The new policy is an exact copy: same rules, same principal " +
+        "(application_id/user_id/group_id), same description and tags. Scaleway's clone API takes NO override " +
+        "fields - the clone's name is identical to the source, so rename it afterward with " +
+        "scaleway_iam_update_policy if a distinct name is needed (nothing references a Policy by name, so " +
+        "renaming is always safe). Prefer this over the manual get+create chain: it copies rules in one step " +
+        "without a window where the copy is only partially built.",
+      inputSchema: cloneSchema,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    },
+    async ({ policy_id }) =>
+      withIamErrorHandling(async () => {
+        const policy = await iamRequest<Policy>(config, "POST", `/policies/${policy_id}/clone`, {});
         return toolJsonResult(policy, config.MAX_OUTPUT_CHARS);
       }),
   );

--- a/src/tools/policies.ts
+++ b/src/tools/policies.ts
@@ -154,20 +154,31 @@ export function registerPolicies(server: McpServer, config: Config) {
     {
       title: "Clone Scaleway IAM Policy",
       description:
-        "Clone an existing IAM Policy in one atomic call (the API's CLONE operation, the console's " +
-        "'Duplicate' action). The new policy is an exact copy: same rules, same principal " +
-        "(application_id/user_id/group_id), same description and tags. Scaleway's clone API takes NO override " +
-        "fields - the clone's name is identical to the source, so rename it afterward with " +
-        "scaleway_iam_update_policy if a distinct name is needed (nothing references a Policy by name, so " +
-        "renaming is always safe). Prefer this over the manual get+create chain: it copies rules in one step " +
-        "without a window where the copy is only partially built.",
+        "Clone an existing IAM Policy. The result is an exact copy: same rules, same principal " +
+        "(application_id/user_id/group_id), same tags. Name gets Scaleway's own 'Copy of <name>' default - rename " +
+        "afterward with scaleway_iam_update_policy if a distinct name is needed (nothing references a Policy by " +
+        "name, so renaming is always safe). Gotcha this tool works around: Scaleway's underlying CLONE endpoint " +
+        "(POST /policies/{id}/clone) ignores its request body entirely and always returns the clone UNATTACHED " +
+        "(no_principal, tags stripped) regardless of the source - confirmed empirically 2026-08-18. This tool " +
+        "follows up with a PATCH restoring the source's principal and tags before returning, so the clone you get " +
+        "back actually matches what 'clone' implies, instead of a silently orphaned policy with no built-in way " +
+        "to reattach it. As with scaleway_iam_create_policy, the response's nb_rules/nb_permission_sets counts can " +
+        "read 0 immediately after this call despite rules having copied correctly - call " +
+        "scaleway_iam_list_policy_rules for ground truth if that count looks wrong.",
       inputSchema: cloneSchema,
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     },
     async ({ policy_id }) =>
       withIamErrorHandling(async () => {
-        const policy = await iamRequest<Policy>(config, "POST", `/policies/${policy_id}/clone`, {});
-        return toolJsonResult(policy, config.MAX_OUTPUT_CHARS);
+        const source = await iamRequest<Policy>(config, "GET", `/policies/${policy_id}`);
+        const clone = await iamRequest<Policy>(config, "POST", `/policies/${policy_id}/clone`, {});
+        const patched = await iamRequest<Policy>(config, "PATCH", `/policies/${clone.id}`, {
+          application_id: source.application_id,
+          user_id: source.user_id,
+          group_id: source.group_id,
+          tags: source.tags,
+        });
+        return toolJsonResult(patched, config.MAX_OUTPUT_CHARS);
       }),
   );
 


### PR DESCRIPTION
Closes #3.

Adds \scaleway_iam_clone_policy\ wrapping the IAM CLONE operation (\POST /policies/{policy_id}/clone\, verified against scaleway-sdk-go). Atomic copy of rules/principal/tags; the clone's name is duplicated (no override fields on the API), so the tool description points to \scaleway_iam_update_policy\ for renaming.

Also marks the policy-clone gap as fixed in \docs/capability-gap-analysis.md\.

Build verified green with \
pm run build\.