### PR TITLE
feat(audit-trail): cover remaining Audit Trail API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,27 @@ Via Claude Code / any MCP client, as a stdio server:
 **Object Storage Bucket Policies**
 - `scaleway_s3_get_bucket_policy`, `scaleway_s3_put_bucket_policy`, `scaleway_s3_delete_bucket_policy`
 
-**Audit Trail**
-- `scaleway_audit_list_events` - who did what, when, from where. Needs `AuditTrailReadOnly` on this server's own credential (organization scope, same rule as `IAMApplicationManager`/`IAMPolicyManager` if already present) - grant via `scaleway_iam_set_policy_rules`.
+**Audit Trail — event queries** (read-only; all need `AuditTrailReadOnly` on this server's credential - grant via `scaleway_iam_set_policy_rules`)
+- `scaleway_audit_list_events` - who did what, when, from where (API/resource activity).
+- `scaleway_audit_list_authentication_events` - authentication activity (login/token/MFA outcomes) - separate endpoint.
+- `scaleway_audit_list_system_events` - actions performed by Scaleway's own systems on your resources.
+- `scaleway_audit_list_combined_events` - all three streams in one chronological feed, each event tagged api/auth/system.
+- `scaleway_audit_get_last_events_overview` - the recent-events snapshot the console's Audit Trail landing page shows.
+- `scaleway_audit_list_products` - products/services/methods integrated with Audit Trail (the valid filter-value catalog).
+
+**Audit Trail — alert rules**
+- `scaleway_audit_list_alert_rules`, `scaleway_audit_set_alert_rules_enabled` (additive), `scaleway_audit_replace_enabled_alert_rules` (full-replace, confirm-guarded) - Scaleway's preconfigured rules; they can only be enabled/disabled, never created or deleted. Unknown rule IDs reject the whole request atomically (live-verified 2026-08-18).
+- `scaleway_audit_list_custom_alert_rules`, `scaleway_audit_create_custom_alert_rule`, `scaleway_audit_update_custom_alert_rule` (name/description only), `scaleway_audit_delete_custom_alert_rule`, `scaleway_audit_set_custom_alert_rules_enabled`, `scaleway_audit_replace_enabled_custom_alert_rules` - **caveat: Scaleway documents these endpoints but the deployed API returns HTTP 501 for every custom-alert-rules method (live-verified 2026-08-18)**. The tools are in place and surface that error verbatim; they'll work when Scaleway ships the backend.
+
+**Audit Trail — export jobs** (ship audit events to an Object Storage bucket)
+- `scaleway_audit_list_export_jobs`, `scaleway_audit_create_export_job`, `scaleway_audit_delete_export_job` (confirm-guarded; stops future exports, doesn't delete already-exported objects).
+- Alert/export write tools need more than `AuditTrailReadOnly` on this server's credential; permission errors surface verbatim.
 
 ## Scope
 
 Deliberately narrow: IAM identity/policy management, Bucket Policies (plus minimal bucket
-create/list/delete, since a policy needs a bucket to attach to), and read-only Audit Trail, because
-that's what actually caused friction so far. Not a general Scaleway API wrapper - no compute,
+create/list/delete, since a policy needs a bucket to attach to), and Audit Trail (event queries,
+alert rules, export jobs), because that's what actually caused friction so far. Not a general Scaleway API wrapper - no compute,
 databases, containers, no bucket visibility/encryption/versioning/lifecycle-rules/website config,
 etc. Extend it the same way if/when those become a recurring need too.
 

--- a/docs/capability-gap-analysis.md
+++ b/docs/capability-gap-analysis.md
@@ -53,13 +53,13 @@ scope boundary is a deliberate, visible line rather than an implicit one.
 | Capability | Console | API | This MCP |
 |---|---|---|---|
 | List events (time range, resource filter) | ✅ | ✅ | ✅ |
-| Authentication events (separate endpoint) | ✅ (implied) | ✅ | ❌ not covered |
-| System events | ❓ | ✅ | ❌ not covered |
-| Combined events / last-events-overview | ❓ | ✅ | ❌ not covered |
-| Export jobs (ship audit logs to storage) | ✅ | ✅ | ❌ not covered |
-| Alert rules + custom alert rules (list/enable/disable/create/update/delete) | ✅ | ✅ | ❌ not covered - this is the one gap in this section with real standalone value (alerting, not just querying), worth a look if Audit Trail becomes a bigger focus |
+| Authentication events (separate endpoint) | ✅ (implied) | ✅ | ✅ **fixed 2026-08-18** (`scaleway_audit_list_authentication_events`) |
+| System events | ❓ | ✅ | ✅ **fixed 2026-08-18** (`scaleway_audit_list_system_events`) |
+| Combined events / last-events-overview | ❓ | ✅ | ✅ **fixed 2026-08-18** (`scaleway_audit_list_combined_events`, `scaleway_audit_get_last_events_overview`, plus `scaleway_audit_list_products` for the filter-value catalog) |
+| Export jobs (ship audit logs to storage) | ✅ | ✅ | ✅ **fixed 2026-08-18** (`scaleway_audit_list/create/delete_export_job`; endpoints verified live, lifecycle not end-to-end exercised to avoid creating real export state) |
+| Alert rules + custom alert rules (list/enable/disable/create/update/delete) | ✅ | ✅ / ⚠️ | ⚠️ **partially fixed 2026-08-18**: preconfigured alert rules fully covered (`list`/`set_enabled`/`replace_enabled`, endpoints live-verified); custom alert rules have all 6 tools implemented, but **Scaleway's deployed API returns HTTP 501 "unknown method" for every custom-alert-rules method** (verified live against fr-par on 2026-08-18 for GET/POST/PUT/PATCH) - documented-but-unimplemented on Scaleway's side; tools will work when the backend ships |
 
-All Audit Trail gaps in this table are tracked together in [#9](https://github.com/logic-arts-official/scaleway-ops-mcp-server/issues/9).
+All Audit Trail gaps in this table were tracked in [#9](https://github.com/logic-arts-official/scaleway-ops-mcp-server/issues/9) - addressed 2026-08-18, except the custom-alert-rules half, which is blocked on Scaleway implementing its own documented API.
 
 ## Bottom line
 
@@ -78,8 +78,10 @@ this session's live re-test - **both fixed and live-verified 2026-08-18**:
    from list.
 
 Everything else in the tables above is a legitimate, deliberate scope boundary (Users/Groups/SSH
-Keys/SAML/SCIM, bucket data-plane and settings, Audit Trail's alerting/export machinery) - not a gap
-so much as a confirmation the README's stated scope is accurate. Each is now tracked as its own
+Keys/SAML/SCIM, bucket data-plane and settings) - not a gap so much as a confirmation the README's
+stated scope is accurate. Audit Trail's alerting/export machinery, originally listed here as out of
+scope, was subsequently implemented (2026-08-18) - see the Audit Trail table above for what works
+and what's blocked on Scaleway's own API. Each remaining gap is tracked as its own
 GitHub issue (labeled `scaleway`) rather than left implicit:
 [#3](https://github.com/logic-arts-official/scaleway-ops-mcp-server/issues/3) policy clone,
 [#4](https://github.com/logic-arts-official/scaleway-ops-mcp-server/issues/4) Users,

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -166,6 +166,30 @@ a total. `scaleway_audit_list_events` treats its `max_pages` as a safety cap, no
 guarantee, and says so in the response (`truncated: true` plus the last `next_page_token`) rather
 than silently stopping.
 
+## Creating an Audit Trail export job immediately backfills past days, it doesn't just start a future cadence
+
+Live-verified 2026-08-18, test-driving `scaleway_audit_create_export_job` (issue #9 / PR #11):
+creating a job against an empty throwaway bucket produced six daily log objects
+(`2026/07/12/logs_*.json` through `2026/07/17/logs_*.json`) within seconds - a backfill of the
+*past* several days, not just events going forward. `scaleway_audit_delete_export_job` explicitly
+does not delete already-exported objects (by design, matching every other delete tool in this
+server), so a bucket created purely to test an export job will NOT be empty afterward -
+`scaleway_s3_delete_bucket` fails `BucketNotEmpty` until those objects are removed, which needs a
+raw S3 call since object-level operations are out of this server's scope.
+
+## Preconfigured alert rules start all-disabled, and the two write tools differ in blast radius
+
+`scaleway_audit_list_alert_rules` returned all 11 preconfigured rules as `disabled` on a
+long-running production Organization (not a fresh account) - nothing is enabled by default.
+Live-verified: `scaleway_audit_set_alert_rules_enabled` (additive) and
+`scaleway_audit_replace_enabled_alert_rules` (full-replace) both reject an unknown rule ID with a
+whole-request `404` and no partial application - confirmed by enabling a real rule alongside a
+fabricated UUID and observing the real one stayed untouched. Only the additive tool was exercised
+live end-to-end (enable -> verify -> disable -> verify reverted); `replace_enabled_alert_rules`
+itself was blocked by Claude Code's own auto-mode safety classifier during this session's test pass
+and remains functionally unverified beyond its shared request-validation behavior - worth a
+deliberate live check before relying on its "everything not listed gets disabled" semantics.
+
 ## Console navigation friction is unrelated to any of the above
 
 Provisioning this same credential manually through the web console (before this server existed)

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -134,5 +134,70 @@ if (bucketListAfter.buckets.some((b) => b.name === throwawayBucket)) {
 }
 console.log("verify gone: bucket no longer in list_buckets");
 
+console.log("\n=== AUDIT TRAIL (issue #9): registered audit tools ===");
+const tools = await client.listTools();
+const auditTools = tools.tools.filter((t) => t.name.startsWith("scaleway_audit_")).map((t) => t.name);
+console.log(auditTools.join("\n"));
+
+console.log("\n=== AUDIT TRAIL (issue #9): read paths (tolerant - permission coverage may vary) ===");
+const auditReads = [
+  ["scaleway_audit_list_authentication_events", { max_pages: 1 }],
+  ["scaleway_audit_list_system_events", { max_pages: 1 }],
+  ["scaleway_audit_list_combined_events", { max_pages: 1 }],
+  ["scaleway_audit_get_last_events_overview", {}],
+  ["scaleway_audit_list_products", {}],
+  ["scaleway_audit_list_alert_rules", {}],
+  ["scaleway_audit_list_custom_alert_rules", {}],
+  ["scaleway_audit_list_export_jobs", {}],
+];
+for (const [name, args] of auditReads) {
+  const res = await client.callTool({ name, arguments: args });
+  const body = text(res).slice(0, 200).replace(/\n/g, " ");
+  console.log(`${res.isError ? "ERROR" : "ok   "} ${name}: ${body}`);
+}
+
+console.log("\n=== AUDIT TRAIL (issue #9): custom alert rule lifecycle (write path - may lack permissions) ===");
+const ruleName = `mcp-smoke-test-alert-${Date.now()}`;
+const createdRule = await client.callTool({
+  name: "scaleway_audit_create_custom_alert_rule",
+  arguments: {
+    name: ruleName,
+    description: "smoke-test rule - safe to delete, deleted by the same run.",
+    query: 'event.method_name == "ListApplications"',
+    occurrences: 1,
+  },
+});
+if (createdRule.isError) {
+  console.log("create blocked (expected if credential lacks Audit Trail write perms):", text(createdRule).slice(0, 300));
+} else {
+  const rule = JSON.parse(text(createdRule));
+  console.log("created rule:", rule.id, "status:", rule.status, "severity:", rule.severity);
+  const updated = await client.callTool({
+    name: "scaleway_audit_update_custom_alert_rule",
+    arguments: { custom_alert_rule_id: rule.id, description: "smoke-test rule - description updated in place." },
+  });
+  if (updated.isError) {
+    console.log("FAILED at update_custom_alert_rule:", text(updated));
+    process.exit(1);
+  }
+  console.log("updated description:", JSON.parse(text(updated)).description);
+  const del = await client.callTool({
+    name: "scaleway_audit_delete_custom_alert_rule",
+    arguments: { custom_alert_rule_id: rule.id, confirm: true },
+  });
+  if (del.isError) {
+    console.log("FAILED at delete_custom_alert_rule:", text(del));
+    process.exit(1);
+  }
+  console.log("deleted rule:", text(del));
+  const listAfter = await client.callTool({ name: "scaleway_audit_list_custom_alert_rules", arguments: {} });
+  const remaining = JSON.parse(text(listAfter)).custom_alert_rules.filter((r) => r.id === rule.id);
+  if (remaining.length > 0) {
+    console.error(`FAILED: rule ${rule.id} still present after delete`);
+    process.exit(1);
+  }
+  console.log("verify gone: rule no longer in list_custom_alert_rules");
+}
+
 await client.close();
 console.log("\nDONE - full read/write/delete lifecycle verified (applications, API keys, buckets)");

--- a/src/auditClient.ts
+++ b/src/auditClient.ts
@@ -20,10 +20,19 @@ function formatAuditErrorBody(status: number, body: unknown): string {
   return `Scaleway Audit Trail API error (HTTP ${status})`;
 }
 
-export async function auditRequest<T>(config: Config, path: string): Promise<T> {
+export async function auditRequest<T>(
+  config: Config,
+  path: string,
+  options: { method?: string; body?: unknown } = {},
+): Promise<T> {
+  const { method = "GET", body } = options;
+  const headers: Record<string, string> = { "X-Auth-Token": config.SCW_SECRET_KEY };
+  if (body) headers["Content-Type"] = "application/json";
+
   const res = await fetch(`${AUDIT_TRAIL_BASE_URL}${path}`, {
-    method: "GET",
-    headers: { "X-Auth-Token": config.SCW_SECRET_KEY },
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
   });
 
   const text = await res.text();

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { registerPermissionSets } from "./tools/permissionSets.js";
 import { registerBuckets } from "./tools/buckets.js";
 import { registerBucketPolicies } from "./tools/bucketPolicies.js";
 import { registerAuditTrail } from "./tools/auditTrail.js";
+import { registerAuditTrailAlerts } from "./tools/auditTrailAlerts.js";
+import { registerAuditTrailExports } from "./tools/auditTrailExports.js";
 
 const config = loadConfig();
 
@@ -24,6 +26,8 @@ registerPermissionSets(server, config);
 registerBuckets(server, config);
 registerBucketPolicies(server, config);
 registerAuditTrail(server, config);
+registerAuditTrailAlerts(server, config);
+registerAuditTrailExports(server, config);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/tools/auditTrail.ts
+++ b/src/tools/auditTrail.ts
@@ -1,50 +1,59 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Config } from "../config.js";
-import { auditRequest, AuditTrailApiError } from "../auditClient.js";
-import { toolJsonResult, toolError } from "../output.js";
-
-interface AuditResource {
-  type: string;
-  id: string;
-  name?: string;
-}
-
-interface AuditEvent {
-  id: string;
-  recorded_at: string | null;
-  principal: { id: string };
-  organization_id: string;
-  project_id?: string | null;
-  source_ip: string;
-  user_agent?: string | null;
-  product_name: string;
-  service_name: string;
-  method_name: string;
-  resources: AuditResource[];
-  request_id: string;
-  request_body?: unknown;
-  status_code: number;
-}
+import { auditRequest } from "../auditClient.js";
+import { toolJsonResult } from "../output.js";
+import {
+  auditRegionSchema,
+  compactApiEvent,
+  compactAuthEvent,
+  compactCombinedEvent,
+  compactSystemEvent,
+  cursorPaginate,
+  defaultRecordedAfter,
+  handleAudit,
+  maxPagesSchema,
+  recordedAfterSchema,
+  recordedBeforeSchema,
+  type ApiAuditEvent,
+  type AuthAuditEvent,
+  type CombinedAuditEvent,
+  type SystemAuditEvent,
+} from "./auditTrailShared.js";
 
 interface ListEventsResponse {
-  events: AuditEvent[];
+  events: ApiAuditEvent[];
   next_page_token?: string | null;
 }
 
-async function handleAudit<T>(fn: () => Promise<T>): Promise<T | ReturnType<typeof toolError>> {
-  try {
-    return await fn();
-  } catch (err) {
-    if (err instanceof AuditTrailApiError) return toolError(err.message) as unknown as T;
-    throw err;
-  }
+interface ListAuthenticationEventsResponse {
+  events: AuthAuditEvent[];
+  next_page_token?: string | null;
+}
+
+interface ListSystemEventsResponse {
+  events: SystemAuditEvent[];
+  next_page_token?: string | null;
+}
+
+interface ListCombinedEventsResponse {
+  events: CombinedAuditEvent[];
+  next_page_token?: string | null;
+}
+
+interface EventsOverviewResponse {
+  last_events: ApiAuditEvent[];
+}
+
+interface ListProductsResponse {
+  products: { title: string; name: string; services: { name: string; methods: string[] }[] }[];
+  total_count: number;
 }
 
 const listSchema = {
-  region: z.enum(["fr-par", "nl-ams"]).optional().describe("Defaults to the server's configured region (fr-par)."),
-  recorded_after: z.string().optional().describe("ISO 8601 date-time, inclusive. Defaults to 24 hours ago."),
-  recorded_before: z.string().optional().describe("ISO 8601 date-time, exclusive. Defaults to now (omitted from the request)."),
+  region: auditRegionSchema,
+  recorded_after: recordedAfterSchema,
+  recorded_before: recordedBeforeSchema,
   resource_type: z
     .string()
     .optional()
@@ -56,9 +65,52 @@ const listSchema = {
     .string()
     .optional()
     .describe("Client-side substring filter against method_name, e.g. 'CreateApplication'. Not a real query param on this API - applied after fetching."),
-  max_pages: z.number().int().min(1).max(50).optional().describe("Safety cap on pagination (100 events/page). Default 20 (up to 2000 events). This API has no total_count, so completeness can't be confirmed beyond the cap."),
+  max_pages: maxPagesSchema.describe("Safety cap on pagination (100 events/page). Default 20 (up to 2000 events). This API has no total_count, so completeness can't be confirmed beyond the cap."),
   full_detail: z.boolean().optional().describe("false (default): drop request_id/user_agent/request_body per event to keep the response compact. true: return every field the API provides."),
 };
+
+const authEventsSchema = {
+  region: auditRegionSchema,
+  recorded_after: recordedAfterSchema,
+  recorded_before: recordedBeforeSchema,
+  order_by: z.enum(["recorded_at_desc", "recorded_at_asc"]).optional().describe("Default recorded_at_desc (newest first)."),
+  max_pages: maxPagesSchema,
+  full_detail: z.boolean().optional().describe("false (default): drop user_agent and per-resource detail blobs. true: return every field the API provides."),
+};
+
+const systemEventsSchema = {
+  region: auditRegionSchema,
+  recorded_after: recordedAfterSchema,
+  recorded_before: recordedBeforeSchema,
+  order_by: z.enum(["recorded_at_desc", "recorded_at_asc"]).optional().describe("Default recorded_at_desc (newest first)."),
+  max_pages: maxPagesSchema,
+  full_detail: z.boolean().optional().describe("false (default): drop locality/project_id and per-resource detail blobs. true: return every field the API provides."),
+};
+
+const combinedEventsSchema = {
+  region: auditRegionSchema,
+  project_id: z.string().uuid().optional().describe("Filter to one Project. Omit for the whole Organization."),
+  resource_type: z.string().optional().describe("Server-side filter on Scaleway's resource_type values - see scaleway_audit_list_products for the catalog."),
+  recorded_after: recordedAfterSchema,
+  recorded_before: recordedBeforeSchema,
+  order_by: z.enum(["recorded_at_desc", "recorded_at_asc"]).optional().describe("Default recorded_at_desc (newest first)."),
+  max_pages: maxPagesSchema,
+  full_detail: z.boolean().optional().describe("false (default): each event is compacted per its kind (api/auth/system). true: return every field the API provides."),
+};
+
+const overviewSchema = {
+  region: auditRegionSchema,
+  project_id: z.string().uuid().optional().describe("Filter to one Project. Omit for the whole Organization."),
+  full_detail: z.boolean().optional().describe("false (default): drop request_id/user_agent/request_body per event. true: return every field the API provides."),
+};
+
+const productsSchema = {
+  region: auditRegionSchema,
+};
+
+const READ_NOTE =
+  "Requires the AuditTrailReadOnly permission set on THIS server's own credential; if every call fails with " +
+  "permissions_denied, that's very likely why - grant it via scaleway_iam_set_policy_rules (organization scope).";
 
 export function registerAuditTrail(server: McpServer, config: Config) {
   server.registerTool(
@@ -67,67 +119,234 @@ export function registerAuditTrail(server: McpServer, config: Config) {
       title: "List Scaleway Audit Trail events",
       description:
         "List Audit Trail events (who did what, when, from where, against what) across this Organization - the " +
-        "same data as the console's Audit Trail > Events page. Requires the AuditTrailReadOnly permission set on " +
-        "THIS server's own credential; if every call fails with permissions_denied, that's very likely why - grant " +
-        "it via scaleway_iam_set_policy_rules (organization scope, same rule as IAMApplicationManager/" +
-        "IAMPolicyManager if this server already has those). Defaults to the last 24 hours. Pagination is " +
-        "cursor-based with no total_count - max_pages is a safety cap, not a completeness guarantee; the response " +
-        "says whether it was truncated and includes the last page token to continue from.",
+          "same data as the console's Audit Trail > Events page. " +
+          READ_NOTE +
+          " Defaults to the last 24 hours. Pagination is " +
+          "cursor-based with no total_count - max_pages is a safety cap, not a completeness guarantee; the response " +
+          "says whether it was truncated and includes the last page token to continue from.",
       inputSchema: listSchema,
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
     async ({ region, recorded_after, recorded_before, resource_type, method_name_contains, max_pages, full_detail }) =>
       handleAudit(async () => {
         const r = region ?? config.SCW_DEFAULT_REGION;
-        const after = recorded_after ?? new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+        const after = recorded_after ?? defaultRecordedAfter();
         const cap = max_pages ?? 20;
 
-        const all: AuditEvent[] = [];
-        let pageToken: string | undefined;
-        let truncated = false;
+        const { items: events, truncated, nextPageToken } = await cursorPaginate<ApiAuditEvent>(
+          async (pageToken) => {
+            const qp = new URLSearchParams({
+              organization_id: config.SCW_ORGANIZATION_ID,
+              recorded_after: after,
+              order_by: "recorded_at_desc",
+              page_size: "100",
+            });
+            if (recorded_before) qp.set("recorded_before", recorded_before);
+            if (resource_type) qp.set("resource_type", resource_type);
+            if (pageToken) qp.set("page_token", pageToken);
+            const data = await auditRequest<ListEventsResponse>(config, `/regions/${r}/events?${qp.toString()}`);
+            return { items: data.events ?? [], next_page_token: data.next_page_token };
+          },
+          cap,
+        );
 
-        for (let page = 0; page < cap; page++) {
-          const qp = new URLSearchParams({
-            organization_id: config.SCW_ORGANIZATION_ID,
-            recorded_after: after,
-            order_by: "recorded_at_desc",
-            page_size: "100",
-          });
-          if (recorded_before) qp.set("recorded_before", recorded_before);
-          if (resource_type) qp.set("resource_type", resource_type);
-          if (pageToken) qp.set("page_token", pageToken);
-
-          const data = await auditRequest<ListEventsResponse>(config, `/regions/${r}/events?${qp.toString()}`);
-          all.push(...(data.events ?? []));
-
-          if (!data.next_page_token) {
-            pageToken = undefined;
-            break;
-          }
-          pageToken = data.next_page_token;
-          if (page === cap - 1) truncated = true;
-        }
-
-        let events = all;
+        let filtered = events;
         if (method_name_contains) {
           const needle = method_name_contains.toLowerCase();
-          events = events.filter((e) => e.method_name.toLowerCase().includes(needle));
+          filtered = filtered.filter((e) => e.method_name.toLowerCase().includes(needle));
         }
-        if (!full_detail) {
-          events = events.map((e) => ({
-            id: e.id,
-            recorded_at: e.recorded_at,
-            principal: e.principal,
-            product_name: e.product_name,
-            service_name: e.service_name,
-            method_name: e.method_name,
-            resources: e.resources,
-            status_code: e.status_code,
-          })) as AuditEvent[];
-        }
+        const out = full_detail ? filtered : filtered.map(compactApiEvent);
 
         return toolJsonResult(
-          { count: events.length, truncated, next_page_token: pageToken ?? null, events },
+          { count: out.length, truncated, next_page_token: nextPageToken, events: out },
+          config.MAX_OUTPUT_CHARS,
+        );
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_list_authentication_events",
+    {
+      title: "List Scaleway Audit Trail authentication events",
+      description:
+        "List authentication events (logins, API-key/token auth, MFA outcomes - success/failure, origin, " +
+          "country, method) across this Organization. A separate endpoint from scaleway_audit_list_events: those " +
+          "cover API/resource activity, these cover authentication activity only. " +
+          READ_NOTE +
+          " Defaults to the last 24 hours. Cursor-based pagination with no total_count, same caveats as " +
+          "scaleway_audit_list_events.",
+      inputSchema: authEventsSchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, recorded_after, recorded_before, order_by, max_pages, full_detail }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const after = recorded_after ?? defaultRecordedAfter();
+        const cap = max_pages ?? 20;
+
+        const { items: events, truncated, nextPageToken } = await cursorPaginate<AuthAuditEvent>(
+          async (pageToken) => {
+            const qp = new URLSearchParams({
+              organization_id: config.SCW_ORGANIZATION_ID,
+              recorded_after: after,
+              order_by: order_by ?? "recorded_at_desc",
+              page_size: "100",
+            });
+            if (recorded_before) qp.set("recorded_before", recorded_before);
+            if (pageToken) qp.set("page_token", pageToken);
+            const data = await auditRequest<ListAuthenticationEventsResponse>(
+              config,
+              `/regions/${r}/authentication-events?${qp.toString()}`,
+            );
+            return { items: data.events ?? [], next_page_token: data.next_page_token };
+          },
+          cap,
+        );
+
+        const out = full_detail ? events : events.map(compactAuthEvent);
+        return toolJsonResult(
+          { count: out.length, truncated, next_page_token: nextPageToken, events: out },
+          config.MAX_OUTPUT_CHARS,
+        );
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_list_system_events",
+    {
+      title: "List Scaleway Audit Trail system events",
+      description:
+        "List system events - actions performed by Scaleway's own systems on your resources (product_name / " +
+          "system_name / kind), rather than by a user or application. The third event stream besides " +
+          "scaleway_audit_list_events (API activity) and scaleway_audit_list_authentication_events " +
+          "(authentication). " +
+          READ_NOTE +
+          " Defaults to the last 24 hours (the API's own default window is 1 hour, so this tool pins it " +
+          "explicitly). Cursor-based pagination with no total_count, same caveats as scaleway_audit_list_events.",
+      inputSchema: systemEventsSchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, recorded_after, recorded_before, order_by, max_pages, full_detail }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const after = recorded_after ?? defaultRecordedAfter();
+        const cap = max_pages ?? 20;
+
+        const { items: events, truncated, nextPageToken } = await cursorPaginate<SystemAuditEvent>(
+          async (pageToken) => {
+            const qp = new URLSearchParams({
+              organization_id: config.SCW_ORGANIZATION_ID,
+              recorded_after: after,
+              order_by: order_by ?? "recorded_at_desc",
+              page_size: "100",
+            });
+            if (recorded_before) qp.set("recorded_before", recorded_before);
+            if (pageToken) qp.set("page_token", pageToken);
+            const data = await auditRequest<ListSystemEventsResponse>(config, `/regions/${r}/system-events?${qp.toString()}`);
+            return { items: data.events ?? [], next_page_token: data.next_page_token };
+          },
+          cap,
+        );
+
+        const out = full_detail ? events : events.map(compactSystemEvent);
+        return toolJsonResult(
+          { count: out.length, truncated, next_page_token: nextPageToken, events: out },
+          config.MAX_OUTPUT_CHARS,
+        );
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_list_combined_events",
+    {
+      title: "List Scaleway Audit Trail combined events",
+      description:
+        "List all three Audit Trail event streams in one chronological feed - each event is tagged with its " +
+          "kind (api, auth, or system) and compacted per-kind. Use this when investigating a timeline across " +
+          "streams; use the per-stream tools (scaleway_audit_list_events, _list_authentication_events, " +
+          "_list_system_events) when one stream is enough. " +
+          READ_NOTE +
+          " Defaults to the last 24 hours. Cursor-based pagination with no total_count, same caveats as " +
+          "scaleway_audit_list_events.",
+      inputSchema: combinedEventsSchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, project_id, resource_type, recorded_after, recorded_before, order_by, max_pages, full_detail }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const after = recorded_after ?? defaultRecordedAfter();
+        const cap = max_pages ?? 20;
+
+        const { items: events, truncated, nextPageToken } = await cursorPaginate<CombinedAuditEvent>(
+          async (pageToken) => {
+            const qp = new URLSearchParams({
+              organization_id: config.SCW_ORGANIZATION_ID,
+              recorded_after: after,
+              order_by: order_by ?? "recorded_at_desc",
+              page_size: "100",
+            });
+            if (project_id) qp.set("project_id", project_id);
+            if (resource_type) qp.set("resource_type", resource_type);
+            if (recorded_before) qp.set("recorded_before", recorded_before);
+            if (pageToken) qp.set("page_token", pageToken);
+            const data = await auditRequest<ListCombinedEventsResponse>(config, `/regions/${r}/combined-events?${qp.toString()}`);
+            return { items: data.events ?? [], next_page_token: data.next_page_token };
+          },
+          cap,
+        );
+
+        const out = full_detail ? events : events.map(compactCombinedEvent);
+        return toolJsonResult(
+          { count: out.length, truncated, next_page_token: nextPageToken, events: out },
+          config.MAX_OUTPUT_CHARS,
+        );
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_get_last_events_overview",
+    {
+      title: "Get Scaleway Audit Trail last-events overview",
+      description:
+        "Get the snapshot of most recent Audit Trail events the console shows on the Audit Trail landing page " +
+          "- the last handful of api events, no filters, no pagination. Handy as a cheap 'anything happening " +
+          "lately?' check before running a full paginated query. " +
+          READ_NOTE,
+      inputSchema: overviewSchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, project_id, full_detail }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const qp = new URLSearchParams({ organization_id: config.SCW_ORGANIZATION_ID });
+        if (project_id) qp.set("project_id", project_id);
+        const data = await auditRequest<EventsOverviewResponse>(config, `/regions/${r}/last-events-overview?${qp.toString()}`);
+        const events = data.last_events ?? [];
+        const out = full_detail ? events : events.map(compactApiEvent);
+        return toolJsonResult({ count: out.length, last_events: out }, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_list_products",
+    {
+      title: "List Scaleway products integrated with Audit Trail",
+      description:
+        "List the products/services integrated with Audit Trail, with their service and method names - the " +
+          "catalog behind the resource_type / product_name / service_name / method_name filters of the " +
+          "scaleway_audit_list_* event tools. Call this when a filter value is rejected or to discover valid " +
+          "values before querying. " +
+          READ_NOTE,
+      inputSchema: productsSchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const qp = new URLSearchParams({ organization_id: config.SCW_ORGANIZATION_ID });
+        const data = await auditRequest<ListProductsResponse>(config, `/regions/${r}/products?${qp.toString()}`);
+        return toolJsonResult(
+          { total_count: data.total_count, products: data.products ?? [] },
           config.MAX_OUTPUT_CHARS,
         );
       }),

--- a/src/tools/auditTrailAlerts.ts
+++ b/src/tools/auditTrailAlerts.ts
@@ -1,0 +1,400 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Config } from "../config.js";
+import { auditRequest } from "../auditClient.js";
+import { toolJsonResult } from "../output.js";
+import {
+  auditRegionSchema,
+  confirmSchema,
+  handleAudit,
+  maxPagesSchema,
+  numberPaginate,
+  WRITE_PERMISSIONS_NOTE,
+} from "./auditTrailShared.js";
+
+interface AlertRule {
+  id: string;
+  name: string;
+  description?: string | null;
+  status: string;
+}
+
+interface CustomAlertRule {
+  id: string;
+  name: string;
+  description?: string | null;
+  status: string;
+  query: string;
+  evaluation_window?: string | null;
+  occurrences: number;
+  severity?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+interface ListAlertRulesResponse {
+  alert_rules: AlertRule[];
+  total_count: number;
+}
+
+interface ListCustomAlertRulesResponse {
+  custom_alert_rules: CustomAlertRule[];
+  total_count: number;
+}
+
+interface MutateAlertRulesResponse {
+  alert_rules: AlertRule[];
+}
+
+interface MutateCustomAlertRulesResponse {
+  custom_alert_rules: CustomAlertRule[];
+}
+
+const statusFilterSchema = z
+  .enum(["enabled", "disabled", "enabling", "disabling"])
+  .optional()
+  .describe("Filter by current status. Omit to list all rules regardless of status.");
+
+const alertRulesCommon = {
+  region: auditRegionSchema,
+  status: statusFilterSchema,
+  max_pages: maxPagesSchema,
+};
+
+const setEnabledSchema = {
+  region: auditRegionSchema,
+  rule_ids: z.array(z.string().uuid()).min(1).describe("IDs of the preconfigured rules to enable or disable - from scaleway_audit_list_alert_rules."),
+  enabled: z.boolean().describe("true: enable exactly these rules (others untouched). false: disable exactly these rules (others untouched)."),
+};
+
+const replaceEnabledSchema = {
+  region: auditRegionSchema,
+  enabled_alert_rule_ids: z
+    .array(z.string().uuid())
+    .describe("The COMPLETE set of rule IDs that should be enabled afterwards. Every currently-enabled rule NOT in this list gets disabled. An empty array disables ALL alert rules."),
+  confirm: confirmSchema.describe("Must be explicitly true. This is a full-replace: rules omitted from the list are silently disabled."),
+};
+
+const customListSchema = {
+  region: auditRegionSchema,
+  status: statusFilterSchema,
+  max_pages: maxPagesSchema,
+};
+
+const customCreateSchema = {
+  region: auditRegionSchema,
+  name: z.string().min(1).describe("Name of the custom alert rule."),
+  description: z.string().optional().describe("What this rule alerts on and why it exists."),
+  query: z
+    .string()
+    .min(1)
+    .describe(
+      "CEL (Common Expression Language) expression defining the match, evaluated against incoming audit events. " +
+        "Scaleway does not document the full field surface here - an invalid expression is rejected by the API with " +
+        "the reason in the error message.",
+    ),
+  evaluation_window: z
+    .string()
+    .optional()
+    .describe('How far back to look for matching events, as a duration string, e.g. "300s". Omit for the API default.'),
+  occurrences: z
+    .number()
+    .int()
+    .min(1)
+    .describe("Minimum number of matching events within the evaluation window required to trigger the alert."),
+  severity: z.enum(["info", "error", "warning", "critical"]).optional().describe("Severity assigned to the alert. Default info."),
+};
+
+const customUpdateSchema = {
+  region: auditRegionSchema,
+  custom_alert_rule_id: z.string().uuid().describe("ID of the custom alert rule to update - from scaleway_audit_list_custom_alert_rules."),
+  name: z.string().min(1).optional().describe("New name. Omit to leave unchanged."),
+  description: z.string().optional().describe("New description. Omit to leave unchanged."),
+};
+
+const customDeleteSchema = {
+  region: auditRegionSchema,
+  custom_alert_rule_id: z.string().uuid().describe("ID of the custom alert rule to delete - from scaleway_audit_list_custom_alert_rules."),
+  confirm: confirmSchema.describe("Must be explicitly true. Deletion is immediate and irreversible."),
+};
+
+const customSetEnabledSchema = {
+  region: auditRegionSchema,
+  rule_ids: z.array(z.string().uuid()).min(1).describe("IDs of the custom rules to enable or disable - from scaleway_audit_list_custom_alert_rules."),
+  enabled: z.boolean().describe("true: enable exactly these rules (others untouched). false: disable exactly these rules (others untouched)."),
+};
+
+const customReplaceEnabledSchema = {
+  region: auditRegionSchema,
+  enabled_custom_alert_rule_ids: z
+    .array(z.string().uuid())
+    .describe("The COMPLETE set of custom rule IDs that should be enabled afterwards. Every currently-enabled custom rule NOT in this list gets disabled. An empty array disables ALL custom alert rules."),
+  confirm: confirmSchema.describe("Must be explicitly true. This is a full-replace: rules omitted from the list are silently disabled."),
+};
+
+const customRulesNote =
+  "CAVEAT (live-verified 2026-08-18): Scaleway documents the custom-alert-rules endpoints, but the deployed API " +
+  "(fr-par) returns HTTP 501 'unknown method' for every custom-alert-rules method - this tool is kept for when " +
+  "Scaleway implements them and currently surfaces that error verbatim. Don't retry on 501; the preconfigured " +
+  "rules via scaleway_audit_list_alert_rules are the working alternative today.";
+
+const atomicRejectNote =
+  "Live-verified 2026-08-18: an unknown rule ID rejects the whole request (HTTP 404) - no partial application.";
+
+export function registerAuditTrailAlerts(server: McpServer, config: Config) {
+  server.registerTool(
+    "scaleway_audit_list_alert_rules",
+    {
+      title: "List Scaleway Audit Trail alert rules",
+      description:
+        "List Scaleway's preconfigured Audit Trail alert rules for this Organization and their current status " +
+          "(enabled/disabled) - the console's Audit Trail > Alerts page. These rules are defined by Scaleway and " +
+          "cannot be created or deleted, only enabled/disabled. " +
+          WRITE_PERMISSIONS_NOTE,
+      inputSchema: alertRulesCommon,
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, status, max_pages }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const { items, total_count, truncated } = await numberPaginate<AlertRule>(
+          async (page) => {
+            const qp = new URLSearchParams({
+              organization_id: config.SCW_ORGANIZATION_ID,
+              page: String(page),
+              page_size: "100",
+            });
+            if (status) qp.set("status", status);
+            const data = await auditRequest<ListAlertRulesResponse>(config, `/regions/${r}/alert-rules?${qp.toString()}`);
+            return { items: data.alert_rules ?? [], total_count: data.total_count ?? 0 };
+          },
+          max_pages ?? 20,
+        );
+        return toolJsonResult({ total_count, count: items.length, truncated, alert_rules: items }, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_set_alert_rules_enabled",
+    {
+      title: "Enable or disable Scaleway Audit Trail alert rules",
+      description:
+        "Enable or disable specific preconfigured Audit Trail alert rules by ID. Touches ONLY the listed rules - " +
+          "the enabled/disabled state of every other rule is left unchanged (unlike " +
+          "scaleway_audit_replace_enabled_alert_rules, which rewrites the whole enabled set). " +
+          "Get IDs from scaleway_audit_list_alert_rules. " +
+          atomicRejectNote +
+          " " +
+          WRITE_PERMISSIONS_NOTE,
+      inputSchema: setEnabledSchema,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, rule_ids, enabled }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const action = enabled ? "enable-alert-rules" : "disable-alert-rules";
+        const data = await auditRequest<MutateAlertRulesResponse>(config, `/regions/${r}/${action}`, {
+          method: "POST",
+          body: { organization_id: config.SCW_ORGANIZATION_ID, alert_rule_ids: rule_ids },
+        });
+        return toolJsonResult({ enabled, affected: data.alert_rules ?? [] }, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_replace_enabled_alert_rules",
+    {
+      title: "Replace the enabled set of Scaleway Audit Trail alert rules",
+      description:
+        "Atomically replace the COMPLETE set of enabled preconfigured alert rules: after this call, exactly the " +
+          "listed rules are enabled and every other preconfigured rule is disabled - including ones you did not " +
+          "mention. Prefer scaleway_audit_set_alert_rules_enabled (additive) unless you genuinely want " +
+          "full-replace semantics, e.g. syncing to a declared state. " +
+          atomicRejectNote +
+          " Requires confirm=true. " +
+          WRITE_PERMISSIONS_NOTE,
+      inputSchema: replaceEnabledSchema,
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, enabled_alert_rule_ids }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const data = await auditRequest<MutateAlertRulesResponse>(config, `/regions/${r}/alert-rules`, {
+          method: "PATCH",
+          body: { organization_id: config.SCW_ORGANIZATION_ID, enabled_alert_rule_ids },
+        });
+        return toolJsonResult({ now_enabled: data.alert_rules ?? [] }, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_list_custom_alert_rules",
+    {
+      title: "List Scaleway Audit Trail custom alert rules",
+      description:
+        "List this Organization's custom Audit Trail alert rules (CEL-expression alerts you created) with their " +
+          "query, evaluation window, occurrence threshold, severity, and enabled/disabled status. Distinct from " +
+          "scaleway_audit_list_alert_rules, which lists Scaleway's preconfigured rules. " +
+          WRITE_PERMISSIONS_NOTE +
+          " " +
+          customRulesNote,
+      inputSchema: customListSchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, status, max_pages }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const { items, total_count, truncated } = await numberPaginate<CustomAlertRule>(
+          async (page) => {
+            const qp = new URLSearchParams({
+              organization_id: config.SCW_ORGANIZATION_ID,
+              page: String(page),
+              page_size: "100",
+            });
+            if (status) qp.set("status", status);
+            const data = await auditRequest<ListCustomAlertRulesResponse>(config, `/regions/${r}/custom-alert-rules?${qp.toString()}`);
+            return { items: data.custom_alert_rules ?? [], total_count: data.total_count ?? 0 };
+          },
+          max_pages ?? 20,
+        );
+        return toolJsonResult(
+          { total_count, count: items.length, truncated, custom_alert_rules: items },
+          config.MAX_OUTPUT_CHARS,
+        );
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_create_custom_alert_rule",
+    {
+      title: "Create a Scaleway Audit Trail custom alert rule",
+      description:
+        "Create a custom Audit Trail alert rule: a CEL expression evaluated against incoming audit events, " +
+          "firing when at least `occurrences` matching events land within `evaluation_window`. " +
+          "Metadata-only edits later via scaleway_audit_update_custom_alert_rule; the query itself cannot be " +
+          "changed in place - to change the logic, create a new rule and delete the old one. " +
+          WRITE_PERMISSIONS_NOTE +
+          " " +
+          customRulesNote,
+      inputSchema: customCreateSchema,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    },
+    async ({ region, name, description, query, evaluation_window, occurrences, severity }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const rule = await auditRequest<CustomAlertRule>(config, `/regions/${r}/custom-alert-rules`, {
+          method: "POST",
+          body: {
+            organization_id: config.SCW_ORGANIZATION_ID,
+            name,
+            description,
+            query,
+            evaluation_window,
+            occurrences,
+            severity,
+          },
+        });
+        return toolJsonResult(rule, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_update_custom_alert_rule",
+    {
+      title: "Update a Scaleway Audit Trail custom alert rule",
+      description:
+        "Update a custom alert rule's metadata (name/description) in place. The API exposes ONLY these two " +
+          "fields on update - the query, evaluation window, occurrences, and severity are immutable after " +
+          "creation; changing the logic means create-new + delete-old. " +
+          WRITE_PERMISSIONS_NOTE +
+          " " +
+          customRulesNote,
+      inputSchema: customUpdateSchema,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, custom_alert_rule_id, name, description }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const rule = await auditRequest<CustomAlertRule>(config, `/regions/${r}/custom-alert-rules/${custom_alert_rule_id}`, {
+          method: "PATCH",
+          body: { name, description },
+        });
+        return toolJsonResult(rule, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_delete_custom_alert_rule",
+    {
+      title: "Delete a Scaleway Audit Trail custom alert rule",
+      description:
+        "PERMANENTLY delete a custom alert rule by ID. Requires confirm=true. Irreversible - the rule's " +
+          "definition is gone, though past events it recorded remain in the event streams. " +
+          WRITE_PERMISSIONS_NOTE +
+          " " +
+          customRulesNote,
+      inputSchema: customDeleteSchema,
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    },
+    async ({ region, custom_alert_rule_id }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        await auditRequest<void>(config, `/regions/${r}/custom-alert-rules/${custom_alert_rule_id}`, {
+          method: "DELETE",
+        });
+        return toolJsonResult({ deleted: true, custom_alert_rule_id }, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_set_custom_alert_rules_enabled",
+    {
+      title: "Enable or disable Scaleway Audit Trail custom alert rules",
+      description:
+        "Enable or disable specific custom alert rules by ID. Touches ONLY the listed rules - the state of " +
+          "every other custom rule is left unchanged (unlike scaleway_audit_replace_enabled_custom_alert_rules, " +
+          "which rewrites the whole enabled set). Get IDs from scaleway_audit_list_custom_alert_rules. " +
+          WRITE_PERMISSIONS_NOTE +
+          " " +
+          customRulesNote,
+      inputSchema: customSetEnabledSchema,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, rule_ids, enabled }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const action = enabled ? "enable-custom-alert-rules" : "disable-custom-alert-rules";
+        const data = await auditRequest<MutateCustomAlertRulesResponse>(config, `/regions/${r}/${action}`, {
+          method: "POST",
+          body: { organization_id: config.SCW_ORGANIZATION_ID, custom_alert_rule_ids: rule_ids },
+        });
+        return toolJsonResult({ enabled, affected: data.custom_alert_rules ?? [] }, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_replace_enabled_custom_alert_rules",
+    {
+      title: "Replace the enabled set of Scaleway Audit Trail custom alert rules",
+      description:
+        "Atomically replace the COMPLETE set of enabled custom alert rules: after this call, exactly the listed " +
+          "custom rules are enabled and every other custom rule is disabled - including ones you did not " +
+          "mention. Prefer scaleway_audit_set_custom_alert_rules_enabled (additive) unless you genuinely want " +
+          "full-replace semantics. Requires confirm=true. " +
+          WRITE_PERMISSIONS_NOTE +
+          " " +
+          customRulesNote,
+      inputSchema: customReplaceEnabledSchema,
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, enabled_custom_alert_rule_ids }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const data = await auditRequest<MutateCustomAlertRulesResponse>(config, `/regions/${r}/custom-alert-rules`, {
+          method: "PUT",
+          body: { organization_id: config.SCW_ORGANIZATION_ID, enabled_custom_alert_rule_ids },
+        });
+        return toolJsonResult({ now_enabled: data.custom_alert_rules ?? [] }, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+}

--- a/src/tools/auditTrailExports.ts
+++ b/src/tools/auditTrailExports.ts
@@ -1,0 +1,149 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Config } from "../config.js";
+import { auditRequest } from "../auditClient.js";
+import { toolJsonResult } from "../output.js";
+import {
+  auditRegionSchema,
+  confirmSchema,
+  handleAudit,
+  maxPagesSchema,
+  numberPaginate,
+  WRITE_PERMISSIONS_NOTE,
+} from "./auditTrailShared.js";
+
+interface ExportJobS3Config {
+  bucket: string;
+  region: string;
+  prefix?: string | null;
+  project_id?: string | null;
+}
+
+interface ExportJob {
+  id: string;
+  organization_id: string;
+  name: string;
+  s3: ExportJobS3Config;
+  created_at?: string | null;
+  last_run_at?: string | null;
+  tags?: string[];
+  last_status?: { code?: string | null; message?: string | null } | null;
+}
+
+interface ListExportJobsResponse {
+  export_jobs: ExportJob[];
+  total_count: number;
+}
+
+const listSchema = {
+  region: auditRegionSchema,
+  name: z.string().optional().describe("Filter by exact export job name."),
+  order_by: z.enum(["name_asc", "name_desc", "created_at_asc", "created_at_desc"]).optional().describe("Default name_asc."),
+  max_pages: maxPagesSchema,
+};
+
+const createSchema = {
+  region: auditRegionSchema,
+  name: z.string().min(1).describe("Name of the export job."),
+  bucket: z.string().min(1).describe("Object Storage bucket the audit events are shipped to. It must already exist - create it first (e.g. scaleway_s3_create_bucket)."),
+  bucket_region: z.enum(["fr-par", "nl-ams", "pl-waw"]).optional().describe("Region of the destination bucket. Defaults to the server's configured region (fr-par)."),
+  prefix: z.string().optional().describe("Key prefix inside the bucket to write under, e.g. 'audit-trail/'."),
+  project_id: z.string().uuid().optional().describe("Project owning the destination bucket. Defaults to the server's configured Project."),
+  tags: z.array(z.string()).optional().describe("Tags for the export job."),
+};
+
+const deleteSchema = {
+  region: auditRegionSchema,
+  export_job_id: z.string().uuid().describe("ID of the export job to delete - from scaleway_audit_list_export_jobs."),
+  confirm: confirmSchema.describe("Must be explicitly true. Stops future exports; already-exported objects in the bucket are NOT deleted."),
+};
+
+export function registerAuditTrailExports(server: McpServer, config: Config) {
+  server.registerTool(
+    "scaleway_audit_list_export_jobs",
+    {
+      title: "List Scaleway Audit Trail export jobs",
+      description:
+        "List this Organization's Audit Trail export jobs - recurring jobs shipping audit events to an Object " +
+          "Storage bucket (S3 destination config, last run, last status). The console's Audit Trail > Exports " +
+          "page. " +
+          WRITE_PERMISSIONS_NOTE,
+      inputSchema: listSchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ region, name, order_by, max_pages }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const { items, total_count, truncated } = await numberPaginate<ExportJob>(
+          async (page) => {
+            const qp = new URLSearchParams({
+              organization_id: config.SCW_ORGANIZATION_ID,
+              page: String(page),
+              page_size: "100",
+              order_by: order_by ?? "name_asc",
+            });
+            if (name) qp.set("name", name);
+            const data = await auditRequest<ListExportJobsResponse>(config, `/regions/${r}/export-jobs?${qp.toString()}`);
+            return { items: data.export_jobs ?? [], total_count: data.total_count ?? 0 };
+          },
+          max_pages ?? 20,
+        );
+        return toolJsonResult({ total_count, count: items.length, truncated, export_jobs: items }, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_create_export_job",
+    {
+      title: "Create a Scaleway Audit Trail export job",
+      description:
+        "Create an export job shipping Audit Trail events to an Object Storage bucket (S3 destination). The " +
+          "bucket must already exist and be writable - create it first (e.g. scaleway_s3_create_bucket). Scaleway " +
+          "does not document here how promptly the first run happens or its exact cadence; check " +
+          "last_run_at / last_status via scaleway_audit_list_export_jobs afterwards. " +
+          WRITE_PERMISSIONS_NOTE,
+      inputSchema: createSchema,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    },
+    async ({ region, name, bucket, bucket_region, prefix, project_id, tags }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        const job = await auditRequest<ExportJob>(config, `/regions/${r}/export-jobs`, {
+          method: "POST",
+          body: {
+            organization_id: config.SCW_ORGANIZATION_ID,
+            name,
+            s3: {
+              bucket,
+              region: bucket_region ?? config.SCW_DEFAULT_REGION,
+              prefix,
+              project_id: project_id ?? config.SCW_PROJECT_ID,
+            },
+            tags,
+          },
+        });
+        return toolJsonResult(job, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+
+  server.registerTool(
+    "scaleway_audit_delete_export_job",
+    {
+      title: "Delete a Scaleway Audit Trail export job",
+      description:
+        "PERMANENTLY delete an export job by ID. Requires confirm=true. Stops future exports; objects already " +
+          "written to the destination bucket are NOT deleted by this call. " +
+          WRITE_PERMISSIONS_NOTE,
+      inputSchema: deleteSchema,
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    },
+    async ({ region, export_job_id }) =>
+      handleAudit(async () => {
+        const r = region ?? config.SCW_DEFAULT_REGION;
+        await auditRequest<void>(config, `/regions/${r}/export-jobs/${export_job_id}`, {
+          method: "DELETE",
+        });
+        return toolJsonResult({ deleted: true, export_job_id }, config.MAX_OUTPUT_CHARS);
+      }),
+  );
+}

--- a/src/tools/auditTrailExports.ts
+++ b/src/tools/auditTrailExports.ts
@@ -98,9 +98,13 @@ export function registerAuditTrailExports(server: McpServer, config: Config) {
       title: "Create a Scaleway Audit Trail export job",
       description:
         "Create an export job shipping Audit Trail events to an Object Storage bucket (S3 destination). The " +
-          "bucket must already exist and be writable - create it first (e.g. scaleway_s3_create_bucket). Scaleway " +
-          "does not document here how promptly the first run happens or its exact cadence; check " +
-          "last_run_at / last_status via scaleway_audit_list_export_jobs afterwards. " +
+          "bucket must already exist and be writable - create it first (e.g. scaleway_s3_create_bucket). " +
+          "Live-verified 2026-08-18: creation triggers an IMMEDIATE backfill, not just a future cadence - a fresh " +
+          "job wrote ~6 days of past daily log objects (one JSON file per day, e.g. '2026/07/12/logs_*.json') into " +
+          "the bucket within seconds of creation. scaleway_audit_delete_export_job does not delete these - if you " +
+          "created a bucket just to test this, you'll need to empty it (object-level operations are out of scope " +
+          "for this server) before scaleway_s3_delete_bucket will succeed. Check last_run_at / last_status via " +
+          "scaleway_audit_list_export_jobs afterwards for the ongoing cadence. " +
           WRITE_PERMISSIONS_NOTE,
       inputSchema: createSchema,
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },

--- a/src/tools/auditTrailShared.ts
+++ b/src/tools/auditTrailShared.ts
@@ -4,7 +4,7 @@ import { AuditTrailApiError } from "../auditClient.js";
 import { toolError } from "../output.js";
 
 export const auditRegionSchema = z
-  .enum(["fr-par", "nl-ams"])
+  .enum(["fr-par", "nl-ams", "pl-waw"])
   .optional()
   .describe("Defaults to the server's configured region (fr-par).");
 

--- a/src/tools/auditTrailShared.ts
+++ b/src/tools/auditTrailShared.ts
@@ -1,0 +1,206 @@
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { AuditTrailApiError } from "../auditClient.js";
+import { toolError } from "../output.js";
+
+export const auditRegionSchema = z
+  .enum(["fr-par", "nl-ams"])
+  .optional()
+  .describe("Defaults to the server's configured region (fr-par).");
+
+export const recordedAfterSchema = z
+  .string()
+  .optional()
+  .describe("ISO 8601 date-time, inclusive. Defaults to 24 hours ago.");
+
+export const recordedBeforeSchema = z
+  .string()
+  .optional()
+  .describe("ISO 8601 date-time, exclusive. Defaults to now (omitted from the request).");
+
+export const maxPagesSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(50)
+  .optional()
+  .describe("Safety cap on pagination (100 items/page). Default 20. Said to be truncated in the response if more pages remained.");
+
+export const confirmSchema = z
+  .literal(true)
+  .describe("Must be explicitly true. Guards a destructive or implicitly-disabling operation.");
+
+export const WRITE_PERMISSIONS_NOTE =
+  "Needs more than AuditTrailReadOnly on THIS server's own credential (read-only covers just the " +
+  "query tools) - if the call fails with permissions_denied, grant the Audit Trail write permission " +
+  "set via scaleway_iam_set_policy_rules.";
+
+export async function handleAudit<T>(fn: () => Promise<T>): Promise<T | ReturnType<typeof toolError>> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof AuditTrailApiError) return toolError(err.message) as unknown as T;
+    throw err;
+  }
+}
+
+export function defaultRecordedAfter(): string {
+  return new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+}
+
+export interface AuditResource {
+  type: string;
+  id: string;
+  name?: string | null;
+}
+
+export function trimResource(r: AuditResource): AuditResource {
+  const out: AuditResource = { type: r.type, id: r.id };
+  if (r.name) out.name = r.name;
+  return out;
+}
+
+export interface ApiAuditEvent {
+  id: string;
+  recorded_at: string | null;
+  principal: { id: string };
+  organization_id: string;
+  project_id?: string | null;
+  source_ip: string;
+  user_agent?: string | null;
+  product_name: string;
+  service_name: string;
+  method_name: string;
+  resources: AuditResource[];
+  request_id: string;
+  request_body?: unknown;
+  status_code: number;
+}
+
+export function compactApiEvent(e: ApiAuditEvent): ApiAuditEvent {
+  return {
+    id: e.id,
+    recorded_at: e.recorded_at,
+    principal: e.principal,
+    product_name: e.product_name,
+    service_name: e.service_name,
+    method_name: e.method_name,
+    resources: (e.resources ?? []).map(trimResource),
+    status_code: e.status_code,
+  } as ApiAuditEvent;
+}
+
+export interface AuthAuditEvent {
+  id: string;
+  recorded_at: string | null;
+  organization_id: string;
+  source_ip: string;
+  user_agent?: string | null;
+  resources: AuditResource[];
+  result?: string | null;
+  failure_reason?: string | null;
+  country_code?: string | null;
+  method?: string | null;
+  origin?: string | null;
+  mfa_type?: string | null;
+}
+
+export function compactAuthEvent(e: AuthAuditEvent): AuthAuditEvent {
+  return {
+    id: e.id,
+    recorded_at: e.recorded_at,
+    source_ip: e.source_ip,
+    result: e.result,
+    failure_reason: e.failure_reason,
+    country_code: e.country_code,
+    method: e.method,
+    origin: e.origin,
+    mfa_type: e.mfa_type,
+    resources: (e.resources ?? []).map(trimResource),
+  } as AuthAuditEvent;
+}
+
+export interface SystemAuditEvent {
+  id: string;
+  recorded_at: string | null;
+  locality?: string | null;
+  organization_id: string;
+  project_id?: string | null;
+  product_name: string;
+  source: string;
+  system_name: string;
+  resources: AuditResource[];
+  kind?: string | null;
+}
+
+export function compactSystemEvent(e: SystemAuditEvent): SystemAuditEvent {
+  return {
+    id: e.id,
+    recorded_at: e.recorded_at,
+    product_name: e.product_name,
+    source: e.source,
+    system_name: e.system_name,
+    kind: e.kind,
+    resources: (e.resources ?? []).map(trimResource),
+  } as SystemAuditEvent;
+}
+
+export interface CombinedAuditEvent {
+  api?: ApiAuditEvent;
+  auth?: AuthAuditEvent;
+  system?: SystemAuditEvent;
+}
+
+export function compactCombinedEvent(e: CombinedAuditEvent): { kind: string; event: unknown } {
+  if (e.api) return { kind: "api", event: compactApiEvent(e.api) };
+  if (e.auth) return { kind: "auth", event: compactAuthEvent(e.auth) };
+  if (e.system) return { kind: "system", event: compactSystemEvent(e.system) };
+  return { kind: "unknown", event: e };
+}
+
+interface CursorPageResponse<T> {
+  items: T[];
+  next_page_token?: string | null;
+}
+
+export async function cursorPaginate<T>(
+  fetchPage: (pageToken: string | undefined) => Promise<CursorPageResponse<T>>,
+  maxPages: number,
+): Promise<{ items: T[]; truncated: boolean; nextPageToken: string | null }> {
+  const items: T[] = [];
+  let token: string | undefined;
+  let truncated = false;
+  for (let page = 0; page < maxPages; page++) {
+    const { items: batch, next_page_token } = await fetchPage(token);
+    items.push(...batch);
+    if (!next_page_token) {
+      token = undefined;
+      break;
+    }
+    token = next_page_token;
+    if (page === maxPages - 1) truncated = true;
+  }
+  return { items, truncated, nextPageToken: token ?? null };
+}
+
+interface NumberedPageResponse<T> {
+  items: T[];
+  total_count: number;
+}
+
+export async function numberPaginate<T>(
+  fetchPage: (page: number) => Promise<NumberedPageResponse<T>>,
+  maxPages: number,
+): Promise<{ items: T[]; total_count: number; truncated: boolean }> {
+  const items: T[] = [];
+  let totalCount = 0;
+  for (let page = 1; page <= maxPages; page++) {
+    const res = await fetchPage(page);
+    totalCount = res.total_count;
+    items.push(...res.items);
+    if (res.items.length === 0 || items.length >= res.total_count) {
+      return { items, total_count: res.total_count, truncated: false };
+    }
+  }
+  return { items, total_count: totalCount, truncated: items.length < totalCount };
+}


### PR DESCRIPTION
Closes #9

## What

17 new Audit Trail tools covering the full documented API surface beyond \GET /events\:

**Event queries (read-only, \AuditTrailReadOnly\)**
- \scaleway_audit_list_authentication_events\ - login/token/MFA outcomes (separate endpoint)
- \scaleway_audit_list_system_events\ - Scaleway-initiated actions on your resources
- \scaleway_audit_list_combined_events\ - all three streams in one chronological feed, each event tagged api/auth/system
- \scaleway_audit_get_last_events_overview\ - the console landing-page snapshot
- \scaleway_audit_list_products\ - the valid filter-value catalog (products/services/methods)

**Preconfigured alert rules** (verified live)
- \scaleway_audit_list_alert_rules\, \scaleway_audit_set_alert_rules_enabled\ (additive), \scaleway_audit_replace_enabled_alert_rules\ (full-replace, confirm-guarded)

**Custom alert rules** (implemented; blocked on Scaleway - see findings)
- full CRUD + additive enable/disable + full-replace: 6 tools

**Export jobs** (verified live)
- \scaleway_audit_list_export_jobs\, \scaleway_audit_create_export_job\, \scaleway_audit_delete_export_job\ (confirm-guarded)

## How

- \uditClient.ts\: now supports POST/PATCH/PUT/DELETE with JSON bodies
- \uditTrailShared.ts\: shared schemas, error handling, cursor + numbered pagination, per-kind event compaction
- Smoke test extended with all new audit tools (tolerant read probes + custom-rule lifecycle)
- README + \docs/capability-gap-analysis.md\ updated

Live-verification findings posted as PR comment (key one: Scaleway's custom-alert-rules API is documented but unimplemented - HTTP 501).