### PR TITLE
chore: gitignore scratch files from live-testing sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ node_modules/
 dist/
 *.env
 .env
+
+# Scratch files from live-testing sessions against the real Scaleway account -
+# not part of the repo, never meant to be committed.
+jfr-analyzer.log*
+tmp-*.mjs
+.tmp-*.mjs


### PR DESCRIPTION
## What

Adds \`jfr-analyzer.log*\`, \`tmp-*.mjs\`, and \`.tmp-*.mjs\` to \`.gitignore\`.

## Why

\`jfr-analyzer.log*\` is debug output from an unrelated tool (a separate Java/Quarkus MCP server), not part of this repo. The \`tmp-*.mjs\`/\`.tmp-*.mjs\` files are throwaway scripts used to live-test tool changes against the real Scaleway account during review/test-drive sessions (e.g. one-off variants of \`scripts/smoke-test.mjs\`'s spawn-a-client pattern) - useful in the moment, never meant to be committed. Both have been showing up as untracked clutter across recent sessions; this just stops them from being accidentally staged.

No code changes.