### PR TITLE
docs: IAM policy naming review and rename (2026-08-18)

### DIFF
--- a/docs/iam-policy-naming-review-2026-08-18.md
+++ b/docs/iam-policy-naming-review-2026-08-18.md
@@ -1,0 +1,41 @@
+# IAM policy naming review (2026-08-18)
+
+Reviewed all 13 IAM Policies in the Organization via `scaleway_iam_list_policies`/
+`scaleway_iam_list_applications`. Naming had drifted across three inconsistent conventions
+(dot vs. dash env prefixes, underscore vs. dash word separators, policy names colliding with
+their Application's own name, remediation history baked into the name instead of the
+description). `Administrators`/`Billing Administrators`/`Editors` are Scaleway's own default
+org groups and were left out of scope.
+
+## Convention adopted
+
+`<env>-<subject>-<access-level>[-<scope>]`, dash-separated throughout (no dots, no
+underscores). Every Object-Storage-scoped policy gets an explicit `-storage` (or `-iam`,
+`-iam-and-storage`) suffix so it never collides with its Application's identically-themed name.
+Historical/remediation context (ticket numbers, "why") stays in `description`, not the name -
+per the "Renaming an Application or Policy is always safe" entry in [gotchas.md](gotchas.md).
+
+## Renames applied and confirmed (10/10)
+
+Applied via `scaleway_iam_update_policy` (`name` field only - no rule/principal/tag changes,
+no credential rotation). Confirmed live via a follow-up `scaleway_iam_list_policies`:
+`nb_rules`/`nb_scopes`/`nb_permission_sets` unchanged on every policy.
+
+| Old name | New name |
+|---|---|
+| `claude-code-operation` | `claude-code-operator-base` |
+| `claude-code-operation-IAM` | `claude-code-operator-iam` |
+| `dev.zvg-files-least-privilege_object_storage` | `dev-zvg-files-least-privilege-storage` |
+| `dev.zvg-files-least-privilege_object_storage_listbucket_fix` | `dev-zvg-files-least-privilege-storage-listbucket` |
+| `local-zvg-files-readonly` | `local-zvg-files-readonly-storage` |
+| `prod-immo-user-documents-rw` | `prod-immo-user-documents-rw-storage` |
+| `prod-zvg-backups-rw` | `prod-zvg-backups-rw-storage` |
+| `prod.zvg-files-least-privilege_object_storage` | `prod-zvg-files-least-privilege-storage` |
+| `scaleway-ops-mcp_iam_and_storage` | `scaleway-ops-mcp-iam-and-storage` |
+| `zvg-backups-least-privilege_object_storage` | `dev-zvg-backups-least-privilege-storage` |
+
+Application names were left untouched; only their attached Policy objects were renamed. Note
+the Application-name layer still carries the same dot-vs-dash inconsistency this review fixed
+on Policies (e.g. `dev.zvg-files-least-privilege` vs. `prod-zvg-backups-rw`) - out of scope
+here since the ask was policy names specifically, but worth a follow-up pass if it's worth
+fixing account-wide.


### PR DESCRIPTION
## Summary
- Reviewed all 13 IAM Policies in the Organization; found naming drift across three inconsistent conventions (dot vs. dash env prefixes, underscore vs. dash word separators, policy names colliding with their Application's own name).
- Adopted a single dash-only convention: `<env>-<subject>-<access-level>[-<scope>]`.
- Renamed all 10 affected policies live via `scaleway_iam_update_policy` (name field only) and confirmed via a follow-up `scaleway_iam_list_policies` that rules/scopes/permission-sets were untouched on every one.
- Scaleway's built-in `Administrators`/`Billing Administrators`/`Editors` policies were left alone.

## Test plan
- [x] Live-applied against the real account, 10/10 renames confirmed via `list_policies`
- [x] Verified `nb_rules`/`nb_scopes`/`nb_permission_sets` identical before/after on every policy (pure rename, no permission drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)