### PR TITLE
chore: prep v0.1.0 for npm publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## 0.1.0
+
+First release. Covers three Scaleway product areas:
+
+### IAM
+
+- Applications: create/get/list/update/delete
+- API keys: create/list/update/delete (update covers description/expiry only, never rotates the secret)
+- Policies: create/get/list/update/delete/clone
+- Policy rules: list / full-replace set
+- Permission sets: list (reference catalog)
+- Users (human members): list/get/create/update/delete, lock/unlock, password/username reset, MFA-OTP delete, grace periods
+- Groups: CRUD plus membership management (add/remove/set members)
+- SSH Keys: list/get/create/update/delete
+- JWTs: get/delete (list is inherently inaccessible to an Application/API-key credential - documented, not a bug)
+- SAML SSO: config get/enable/update/disable, certificate management
+- SCIM provisioning: config get/enable/disable, token management
+- Security Settings: org-wide auth policy get/update
+
+### Object Storage
+
+- Bucket lifecycle: create/list/delete
+- Bucket configuration: visibility, encryption, versioning, Object Lock, static website hosting, lifecycle rules, tags, CORS
+- Bucket Policies: get/put/delete
+- Objects: put/get/list/head/copy/delete, tags, presigned URLs (single-part only, 5 MB default cap - no multipart)
+
+### Audit Trail
+
+- Event queries: events, authentication events, system events, combined feed, last-events overview, products catalog
+- Alert rules: list/enable/disable preconfigured rules; custom alert rule tools are implemented but blocked on Scaleway's own API (documented endpoints return HTTP 501 in production)
+- Export jobs: list/create/delete
+
+See [README.md](README.md) for the full tool list and [docs/gotchas.md](docs/gotchas.md) for
+non-obvious API behavior this server exists to paper over.

--- a/README.md
+++ b/README.md
@@ -36,13 +36,32 @@ Environment variables (see `.env.example`):
 
 **The credential this server runs as needs its own IAM Policy** granting (at minimum)
 `IAMApplicationManager` + `IAMPolicyManager` (organization scope) and `ObjectStorageFullAccess`
-(project scope) - see `docs/gotchas.md` for why these must be two separate policy rules. The
-`scaleway-ops-mcp` Application (provisioned 2026-08-12) already has this; reuse its credential
-rather than minting a new one unless you specifically want a differently-scoped identity.
+(project scope) - see `docs/gotchas.md` for why these must be two separate policy rules. Create a
+dedicated IAM Application for this server (don't reuse a human user's credential or an
+Application scoped for something else) and grant it only what the table above needs.
 
 ## Running
 
-Via Claude Code / any MCP client, as a stdio server:
+Via Claude Code / any MCP client, as a stdio server. Simplest, via `npx` (no local clone needed):
+
+```json
+{
+  "mcpServers": {
+    "scaleway-ops": {
+      "command": "npx",
+      "args": ["-y", "scaleway-ops-mcp-server"],
+      "env": {
+        "SCW_ACCESS_KEY": "...",
+        "SCW_SECRET_KEY": "...",
+        "SCW_ORGANIZATION_ID": "...",
+        "SCW_PROJECT_ID": "..."
+      }
+    }
+  }
+}
+```
+
+Or from a local clone/build, useful for development or pinning to an unreleased commit:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,15 @@
   "bin": {
     "scaleway-ops-mcp-server": "dist/index.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('dist/index.js', 0o755)\"",
+    "prepublishOnly": "npm run build",
     "dev": "tsc --watch",
     "start": "node dist/index.js"
   },
@@ -22,6 +29,14 @@
   ],
   "author": "Gernot Krost <gernot@krost.org>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/logic-arts-official/scaleway-ops-mcp-server.git"
+  },
+  "homepage": "https://github.com/logic-arts-official/scaleway-ops-mcp-server#readme",
+  "bugs": {
+    "url": "https://github.com/logic-arts-official/scaleway-ops-mcp-server/issues"
+  },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1108.0",
     "@aws-sdk/s3-request-presigner": "^3.1112.0",


### PR DESCRIPTION
## Summary
- Add a `files` allowlist to `package.json` (`dist`, `README.md`, `LICENSE`, `CHANGELOG.md`) so `npm publish` doesn't bundle `src/`, `scripts/`, and `docs/` - confirmed via `npm pack --dry-run` that the tarball shrinks from 1.0 MB to 358 KB unpacked with no loss of what's actually needed to run the server.
- Add `prepublishOnly: npm run build` so the published tarball can never be built from a stale `dist/`.
- Add `repository`/`homepage`/`bugs` fields for the npm package page.
- README: add the `npx`-based `mcpServers` config as the primary "Running" path (local build kept as the dev/pin-to-commit alternative) - this becomes the real onboarding path once published.
- README: replace the account-specific "reuse the `scaleway-ops-mcp` Application's credential" line with generic dedicated-credential guidance, since this is about to be a public release rather than an internal note-to-self.
- New `CHANGELOG.md` documenting the full v0.1.0 tool surface across IAM, Object Storage, and Audit Trail.

Version intentionally stays `0.1.0` - first release, not yet signaling a stable API.

## Test plan
- [x] `npm run build` passes clean
- [x] `npm pack --dry-run` confirms `dist/`, `README.md`, `LICENSE`, `CHANGELOG.md` are included and `src/`/`scripts/`/`docs/` are excluded
- [ ] Actual `npm publish` is a separate, deliberate step after this merges - not included here

🤖 Generated with [Claude Code](https://claude.com/claude-code)