### PR TITLE
fix(security): validate access_key/jti format to prevent request path injection

### DIFF
--- a/src/tools/apiKeys.ts
+++ b/src/tools/apiKeys.ts
@@ -36,8 +36,14 @@ const createSchema = {
     .describe("Preferred Project for Object Storage operations with this key. Required if this key will call the S3-compatible API (bucket policies, objects)."),
 };
 
+const accessKeyFormat = /^[A-Za-z0-9]+$/;
+
 const updateSchema = {
-  access_key: z.string().min(1).describe("The access_key (not secret_key) of the key to update, e.g. 'SCWXXXXXXXXXXXXXXXXX'."),
+  access_key: z
+    .string()
+    .min(1)
+    .regex(accessKeyFormat, "access_key is alphanumeric only")
+    .describe("The access_key (not secret_key) of the key to update, e.g. 'SCWXXXXXXXXXXXXXXXXX'."),
   description: z.string().max(200).optional().describe("New description. Omit to leave unchanged."),
   expires_at: z
     .string()
@@ -52,7 +58,11 @@ const listSchema = {
 };
 
 const deleteSchema = {
-  access_key: z.string().min(1).describe("The access_key (not secret_key) identifying the key to delete, e.g. 'SCWXXXXXXXXXXXXXXXXX'."),
+  access_key: z
+    .string()
+    .min(1)
+    .regex(accessKeyFormat, "access_key is alphanumeric only")
+    .describe("The access_key (not secret_key) identifying the key to delete, e.g. 'SCWXXXXXXXXXXXXXXXXX'."),
   confirm: z.literal(true).describe("Must be explicitly true. Deletion is immediate and irreversible - anything using this key stops authenticating right away."),
 };
 

--- a/src/tools/jwts.ts
+++ b/src/tools/jwts.ts
@@ -26,6 +26,11 @@ interface Jwt {
 
 const confirmField = z.literal(true).describe("Must be explicitly true.");
 
+const jtiField = z
+  .string()
+  .min(1)
+  .regex(/^[A-Za-z0-9-]+$/, "jti is alphanumeric/hyphen only");
+
 export function registerJwts(server: McpServer, config: Config) {
   server.registerTool(
     "scaleway_iam_list_jwts",
@@ -52,7 +57,7 @@ export function registerJwts(server: McpServer, config: Config) {
     {
       title: "Get one JWT session by id",
       description: "Read one JWT session's metadata (jti, audience, expiry, IP, user agent) by its id.",
-      inputSchema: { jti: z.string().describe("The JWT's id (jti claim), from scaleway_iam_list_jwts.") },
+      inputSchema: { jti: jtiField.describe("The JWT's id (jti claim), from scaleway_iam_list_jwts.") },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
     async ({ jti }) =>
@@ -70,7 +75,7 @@ export function registerJwts(server: McpServer, config: Config) {
         "Immediately invalidate one active browser/console session. Requires confirm=true. Whoever holds that " +
         "session is signed out right away - same severity as revoking an API key, but for an interactive login " +
         "instead of a programmatic credential.",
-      inputSchema: { jti: z.string(), confirm: confirmField },
+      inputSchema: { jti: jtiField, confirm: confirmField },
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     },
     async ({ jti }) =>


### PR DESCRIPTION
## Summary
Found during a full-codebase audit: `access_key` (apiKeys.ts) and `jti` (jwts.ts) were the only ID-shaped fields in the entire tool set without a Zod format constraint - every other ID field (application_id, user_id, policy_id, group_id, ssh_key_id, saml_id, scim_id, token_id, custom_alert_rule_id, export_job_id, certificate_id) uses `.uuid()`.

Both fields are interpolated directly into the URL path passed to `iamClient.ts`'s `fetch()` call. Because `fetch()`'s URL parsing normalizes `..` path segments before the request is sent, a crafted value in either field could cause the actual HTTP request to land on a different API path than the tool call's own name/description implies - and the `confirm: true` gate present on the destructive tools only validates a boolean, it never inspects the string content of `access_key`/`jti` itself.

## Fix
Added a strict format constraint to both fields, matching Scaleway's real key/token id shapes:
- `access_key`: alphanumeric only (matches every real access key, e.g. `SCWXXXXXXXXXXXXXXXXX`)
- `jti`: alphanumeric + hyphen only

Both are rejected at input validation, before any request is ever built - no behavior change for legitimate values.

## Test plan
- [x] `npm run build` passes clean
- [x] Verified via the real built server (`node dist/index.js` + a raw MCP `tools/call` request) that a crafted `access_key` value containing path-traversal sequences is now rejected with a clean input-validation error instead of reaching `fetch()`
- [x] Verified a legitimate-looking `access_key` (real format) still passes validation and reaches the API call unchanged (fails on auth with fake test credentials, as expected - proving validation didn't over-block real values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)