### PR TITLE
chore: bump to v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented here.
 
+## 0.1.1
+
+Security fix: `access_key` (`scaleway_iam_update_api_key`/`scaleway_iam_delete_api_key`) and `jti`
+(`scaleway_iam_get_jwt`/`scaleway_iam_delete_jwt`) were the only ID-shaped fields in the tool set
+without a format constraint - every other ID field uses `.uuid()`. Both were interpolated
+directly into a request path, and an unexpected value could cause the request this server sends
+to land on a different API path than the tool call's own name/description implies. Both fields
+now require a strict alphanumeric (`access_key`) / alphanumeric-plus-hyphen (`jti`) format,
+matching Scaleway's real key/token id shapes - no behavior change for legitimate values.
+
 ## 0.1.0
 
 First release. Covers three Scaleway product areas:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scaleway-ops-mcp-server
 
-[![CI](https://github.com/logic-arts-official/scaleway-ops-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/logic-arts-official/scaleway-ops-mcp-server/actions/workflows/ci.yml)
+[![CI](https://github.com/gkrost/scaleway-ops-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/gkrost/scaleway-ops-mcp-server/actions/workflows/ci.yml)
 
 MCP server for Scaleway IAM (Applications, API keys, Policies, Permission sets) and Object
 Storage Bucket Policy management.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scaleway-ops-mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server for Scaleway IAM (Applications, API keys, Policies, Permission sets) and Object Storage (buckets, Bucket Policies, object CRUD)",
   "type": "module",
   "main": "dist/index.js",
@@ -31,11 +31,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/logic-arts-official/scaleway-ops-mcp-server.git"
+    "url": "git+https://github.com/gkrost/scaleway-ops-mcp-server.git"
   },
-  "homepage": "https://github.com/logic-arts-official/scaleway-ops-mcp-server#readme",
+  "homepage": "https://github.com/gkrost/scaleway-ops-mcp-server#readme",
   "bugs": {
-    "url": "https://github.com/logic-arts-official/scaleway-ops-mcp-server/issues"
+    "url": "https://github.com/gkrost/scaleway-ops-mcp-server/issues"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1108.0",


### PR DESCRIPTION
## Summary
- Version bump to 0.1.1 for the access_key/jti path-validation security fix (#24, already merged) - that fix touches shipped `dist/` code, so it warrants a patch release, unlike the earlier CodeQL-alert fixes which only touched dev-only/CI files.
- Fixed `package.json`'s `repository`/`homepage`/`bugs` fields and the README CI badge, which still pointed at `logic-arts-official/scaleway-ops-mcp-server` from before the repo transfer to `gkrost/scaleway-ops-mcp-server`.
- CHANGELOG.md: new 0.1.1 entry.

## Test plan
- [x] `npm run build` passes clean, version confirmed 0.1.1
- [ ] `npm publish` is a separate, deliberate step after this merges (needs the maintainer's npm credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)