### PR TITLE
fix(iam): confirm-gate set_policy_rules and refuse self-lockout (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased
+
+- `scaleway_iam_set_policy_rules` now requires `confirm=true` and refuses a full-replace that would drop `IAMPolicyManager`/`IAMApplicationManager` from a policy that currently grants them, so a stale or incomplete rules array cannot permanently lock this credential out of IAM (issue #25).
+
 ## 0.1.1
 
 Security fix: `access_key` (`scaleway_iam_update_api_key`/`scaleway_iam_delete_api_key`) and `jti`

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -150,6 +150,17 @@ itself fail `permissions_denied`, since the credential attempting it no longer h
 that call requires. `SetRules` has no such window: the policy object, and everything that already
 depends on its `id`, never stops existing.
 
+### Distinct lockout: a successful full-replace that omits the IAM-management rule
+
+`set_policy_rules` has a second lockout mode of its own. The PUT is a complete replace, not a
+merge: if the caller reconstructs `rules` from a stale or incomplete `list_policy_rules` read and
+omits the rule granting `IAMPolicyManager`/`IAMApplicationManager`, the call used to succeed
+immediately - and whoever that policy granted IAM management to (including this server) was then
+permanently unable to call `set_policy_rules` or any other IAM policy/application tool to undo it.
+The tool now requires `confirm=true`, and the handler GETs the current rules first and refuses a
+replace that would drop `IAMPolicyManager` or `IAMApplicationManager` from a policy that currently
+has them. Policies that never carried those permission sets are unaffected.
+
 ## `POST /policies/{id}/clone` ignores its request body and always returns the clone unattached
 
 Confirmed empirically 2026-08-18, reviewing `scaleway_iam_clone_policy`: the clone endpoint copies

--- a/src/tools/policies.ts
+++ b/src/tools/policies.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Config } from "../config.js";
 import { iamListAll, iamRequest, withIamErrorHandling } from "../iamClient.js";
-import { toolJsonResult } from "../output.js";
+import { toolJsonResult, toolError } from "../output.js";
 
 interface Rule {
   id: string;
@@ -111,6 +111,12 @@ const setRulesSchema = {
         "append. Call scaleway_iam_list_policy_rules first, add/remove/edit within that array, then pass the " +
         "whole thing back here. This is the safe way to change a live policy's grants: unlike delete+recreate, " +
         "there's no window where the policy (or the permissions it grants its own holder) doesn't exist.",
+    ),
+  confirm: z
+    .literal(true)
+    .describe(
+      "Must be explicitly true. This is a full-replace of live grants: omitting the rule that grants this " +
+        "server IAMPolicyManager/IAMApplicationManager permanently locks the credential out of IAM.",
     ),
 };
 
@@ -264,15 +270,31 @@ export function registerPolicies(server: McpServer, config: Config) {
       title: "Set rules on a Scaleway IAM Policy",
       description:
         "Overwrite the COMPLETE rules array on an existing Policy in one atomic call - the safe way to add or " +
-        "remove a permission set on a live policy. Prefer this over delete+recreate: deleting a policy that " +
-        "grants its own holder IAMPolicyManager revokes that permission the instant it's deleted, before a " +
-        "replacement can be created, which can lock the credential you're using out of IAM entirely. Call " +
+        "remove a permission set on a live policy. Requires confirm=true. Prefer this over delete+recreate: " +
+        "deleting a policy that grants its own holder IAMPolicyManager revokes that permission the instant " +
+        "it's deleted, before a replacement can be created, which can lock the credential you're using out of " +
+        "IAM entirely. Distinct lockout mode: a successful replace that drops this server's IAM-management " +
+        "rule (IAMPolicyManager/IAMApplicationManager) cannot be undone through this server - the credential " +
+        "then cannot call this tool, or any other IAM policy/application tool, to fix itself. Call " +
         "scaleway_iam_list_policy_rules first to get the current array before changing it.",
       inputSchema: setRulesSchema,
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     },
-    async ({ policy_id, rules }) =>
+    async ({ policy_id, rules, confirm }) =>
       withIamErrorHandling(async () => {
+        const current = await iamRequest<{ rules: Rule[]; total_count: number }>(config, "GET", `/rules?policy_id=${policy_id}`);
+        const currentSets = new Set((current.rules ?? []).flatMap((r) => r.permission_set_names));
+        const incomingSets = new Set(rules.flatMap((r) => r.permission_set_names));
+        const droppingPolicyManager = currentSets.has("IAMPolicyManager") && !incomingSets.has("IAMPolicyManager");
+        const droppingApplicationManager =
+          currentSets.has("IAMApplicationManager") && !incomingSets.has("IAMApplicationManager");
+        if (droppingPolicyManager || droppingApplicationManager) {
+          return toolError(
+            "Refusing this replace: it would drop IAMPolicyManager and/or IAMApplicationManager from a policy " +
+              "that currently grants them. That would permanently lock out IAM management for whoever this " +
+              "policy currently grants it to. Include those permission sets in the replacement array.",
+          );
+        }
         const data = await iamRequest<{ rules: Rule[] }>(config, "PUT", `/rules`, { policy_id, rules });
         return toolJsonResult(data, config.MAX_OUTPUT_CHARS);
       }),


### PR DESCRIPTION
Closes #25.

**Stack:** 1/7. Merge this first; #26–#31 are stacked on top.

## Summary
`scaleway_iam_set_policy_rules` is a full-replace `PUT` that was marketed as the safe way to change a live policy, but it had no `confirm` gate. Reconstructing `rules` from a stale `list_policy_rules` read and dropping the `IAMPolicyManager`/`IAMApplicationManager` grant succeeds immediately and permanently locks this credential out of IAM — including this tool itself.

- Require `confirm: true` (same gate as the other full-replace / high-blast-radius tools).
- Before the PUT, GET the current rules. If they include `IAMPolicyManager` or `IAMApplicationManager` and the replacement drops either, refuse with `toolError` and do not write.
- Document this second lockout mode in `docs/gotchas.md` (distinct from the delete+recreate window).

## Test plan
- [x] `npm run build` (`tsc`) passes on the stacked tip
- [ ] Live `confirm` rejection / lockout-refusal not run here (no Scaleway credentials in this environment)