### PR TITLE
fix(audit): confirm-gate create_export_job (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+
 - `scaleway_iam_set_policy_rules` now requires `confirm=true` and refuses a full-replace that would drop `IAMPolicyManager`/`IAMApplicationManager` from a policy that currently grants them, so a stale or incomplete rules array cannot permanently lock this credential out of IAM (issue #25).
 - `scaleway_s3_generate_presigned_url`: `operation: "put"` now requires `confirm=true` and the tool is no longer annotated `readOnlyHint` - a PUT URL exports a time-limited unauthenticated write capability outside the MCP boundary (issue #26).
+- `scaleway_audit_create_export_job` now requires `confirm=true` because creation immediately backfills ~6 days of real audit events into the destination bucket, and `scaleway_audit_delete_export_job` does not remove those objects (#27).
 
 ## 0.1.1
 

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -210,7 +210,8 @@ creating a job against an empty throwaway bucket produced six daily log objects
 does not delete already-exported objects (by design, matching every other delete tool in this
 server), so a bucket created purely to test an export job will NOT be empty afterward -
 `scaleway_s3_delete_bucket` fails `BucketNotEmpty` until those objects are removed, which needs a
-raw S3 call since object-level operations are out of this server's scope.
+raw S3 call since object-level operations are out of this server's scope. The tool now requires
+`confirm=true`.
 
 ## Preconfigured alert rules start all-disabled, and the two write tools differ in blast radius
 

--- a/src/tools/auditTrailExports.ts
+++ b/src/tools/auditTrailExports.ts
@@ -50,6 +50,7 @@ const createSchema = {
   prefix: z.string().optional().describe("Key prefix inside the bucket to write under, e.g. 'audit-trail/'."),
   project_id: z.string().uuid().optional().describe("Project owning the destination bucket. Defaults to the server's configured Project."),
   tags: z.array(z.string()).optional().describe("Tags for the export job."),
+  confirm: confirmSchema.describe("Must be explicitly true. Creation triggers an immediate backfill of real audit events into the destination bucket; delete does not remove those objects."),
 };
 
 const deleteSchema = {
@@ -97,8 +98,8 @@ export function registerAuditTrailExports(server: McpServer, config: Config) {
     {
       title: "Create a Scaleway Audit Trail export job",
       description:
-        "Create an export job shipping Audit Trail events to an Object Storage bucket (S3 destination). The " +
-          "bucket must already exist and be writable - create it first (e.g. scaleway_s3_create_bucket). " +
+        "Create an export job shipping Audit Trail events to an Object Storage bucket (S3 destination). Requires " +
+          "confirm=true. The bucket must already exist and be writable - create it first (e.g. scaleway_s3_create_bucket). " +
           "Live-verified 2026-08-18: creation triggers an IMMEDIATE backfill, not just a future cadence - a fresh " +
           "job wrote ~6 days of past daily log objects (one JSON file per day, e.g. '2026/07/12/logs_*.json') into " +
           "the bucket within seconds of creation. scaleway_audit_delete_export_job does not delete these - if you " +
@@ -109,7 +110,7 @@ export function registerAuditTrailExports(server: McpServer, config: Config) {
       inputSchema: createSchema,
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     },
-    async ({ region, name, bucket, bucket_region, prefix, project_id, tags }) =>
+    async ({ region, name, bucket, bucket_region, prefix, project_id, tags, confirm }) =>
       handleAudit(async () => {
         const r = region ?? config.SCW_DEFAULT_REGION;
         const job = await auditRequest<ExportJob>(config, `/regions/${r}/export-jobs`, {


### PR DESCRIPTION
Closes #27.

**Stack:** 3/7. Base is `fix/26-presigned-url-put-confirm`.

## Summary
`scaleway_audit_create_export_job` immediately backfills ~6 days of real audit events into the destination bucket. `delete_export_job` does not remove those objects (and the residue blocks `delete_bucket`). Sibling tools with comparable blast radius already require `confirm: true`.

- Add `confirm: confirmSchema` to create, with a description covering the immediate backfill and the lack of object cleanup.
- Tool description now says `Requires confirm=true`.
- One sentence in `docs/gotchas.md`.
- Left `destructiveHint: false` — this is a create, gated by confirm, not a delete.

## Test plan
- [x] `npm run build` (`tsc`) passes on the stacked tip
- [ ] Live export-job create not run here (would write real audit objects)