### PR TITLE
fix(s3): validate region as fr-par/nl-ams/pl-waw (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here.
 - `scaleway_iam_set_policy_rules` now requires `confirm=true` and refuses a full-replace that would drop `IAMPolicyManager`/`IAMApplicationManager` from a policy that currently grants them, so a stale or incomplete rules array cannot permanently lock this credential out of IAM (issue #25).
 - `scaleway_s3_generate_presigned_url`: `operation: "put"` now requires `confirm=true` and the tool is no longer annotated `readOnlyHint` - a PUT URL exports a time-limited unauthenticated write capability outside the MCP boundary (issue #26).
 - `scaleway_audit_create_export_job` now requires `confirm=true` because creation immediately backfills ~6 days of real audit events into the destination bucket, and `scaleway_audit_delete_export_job` does not remove those objects (#27).
+- Validate S3 `region` as `fr-par`/`nl-ams`/`pl-waw` instead of a free-form string, so a bad region fails at schema validation rather than an uncaught DNS/TLS error (#28).
 
 ## 0.1.1
 

--- a/src/scwRegion.ts
+++ b/src/scwRegion.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+
+export const SCW_REGIONS = ["fr-par", "nl-ams", "pl-waw"] as const;
+export const scwRegionSchema = z.enum(SCW_REGIONS);

--- a/src/tools/auditTrailShared.ts
+++ b/src/tools/auditTrailShared.ts
@@ -2,9 +2,9 @@ import { z } from "zod";
 import type { Config } from "../config.js";
 import { AuditTrailApiError } from "../auditClient.js";
 import { toolError } from "../output.js";
+import { scwRegionSchema } from "../scwRegion.js";
 
-export const auditRegionSchema = z
-  .enum(["fr-par", "nl-ams", "pl-waw"])
+export const auditRegionSchema = scwRegionSchema
   .optional()
   .describe("Defaults to the server's configured region (fr-par).");
 

--- a/src/tools/bucketConfig.ts
+++ b/src/tools/bucketConfig.ts
@@ -26,6 +26,7 @@ import {
 import type { Config } from "../config.js";
 import { getS3Client, handleS3 } from "../s3Client.js";
 import { toolJsonResult, toolError } from "../output.js";
+import { scwRegionSchema } from "../scwRegion.js";
 
 /**
  * Bucket-level configuration management (issue #7): tagging, CORS, versioning, website,
@@ -35,7 +36,7 @@ import { toolJsonResult, toolError } from "../output.js";
  * Scaleway's S3 endpoint returns NotImplemented for both (live-verified 2026-08-18).
  */
 const bucketField = z.string().min(3).describe("Bucket name.");
-const regionField = z.string().optional().describe("Region to operate in. Defaults to the server's configured region (fr-par).");
+const regionField = scwRegionSchema.optional().describe("Region to operate in. Defaults to the server's configured region (fr-par).");
 const confirmField = z.literal(true).describe("Must be explicitly true.");
 
 const ALL_USERS_URI = "http://acs.amazonaws.com/groups/global/AllUsers";

--- a/src/tools/bucketPolicies.ts
+++ b/src/tools/bucketPolicies.ts
@@ -4,9 +4,10 @@ import { DeleteBucketPolicyCommand, GetBucketPolicyCommand, PutBucketPolicyComma
 import type { Config } from "../config.js";
 import { getS3Client, handleS3 } from "../s3Client.js";
 import { toolJsonResult, toolError } from "../output.js";
+import { scwRegionSchema } from "../scwRegion.js";
 
 const bucketField = z.string().min(3).describe("Bucket name, e.g. 'payments-backups'.");
-const regionField = z.string().optional().describe("Region the bucket lives in. Defaults to the server's configured region (fr-par).");
+const regionField = scwRegionSchema.optional().describe("Region the bucket lives in. Defaults to the server's configured region (fr-par).");
 
 const getSchema = {
   bucket: bucketField,

--- a/src/tools/buckets.ts
+++ b/src/tools/buckets.ts
@@ -4,9 +4,10 @@ import { CreateBucketCommand, DeleteBucketCommand, ListBucketsCommand } from "@a
 import type { Config } from "../config.js";
 import { getS3Client, handleS3 } from "../s3Client.js";
 import { toolJsonResult } from "../output.js";
+import { scwRegionSchema } from "../scwRegion.js";
 
 const bucketField = z.string().min(3).describe("Bucket name, e.g. 'payments-backups'.");
-const regionField = z.string().optional().describe("Region to operate in. Defaults to the server's configured region (fr-par).");
+const regionField = scwRegionSchema.optional().describe("Region to operate in. Defaults to the server's configured region (fr-par).");
 
 const createSchema = {
   bucket: bucketField,

--- a/src/tools/objects.ts
+++ b/src/tools/objects.ts
@@ -15,9 +15,10 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import type { Config } from "../config.js";
 import { getS3Client, handleS3 } from "../s3Client.js";
 import { toolJsonResult, toolError } from "../output.js";
+import { scwRegionSchema } from "../scwRegion.js";
 
 const bucketField = z.string().min(3).describe("Bucket name, e.g. 'payments-backups'.");
-const regionField = z.string().optional().describe("Region the bucket lives in. Defaults to the server's configured region (fr-par).");
+const regionField = scwRegionSchema.optional().describe("Region the bucket lives in. Defaults to the server's configured region (fr-par).");
 const keyField = z.string().min(1).describe("Object key (the full path within the bucket), e.g. 'invoices/2026-08/inv-001.pdf'.");
 
 /** URI-encode each path segment of a key but keep the '/' separators literal - required by S3's CopySource format. */


### PR DESCRIPTION
Closes #28.

**Stack:** 4/7. Base is `fix/27-create-export-job-confirm`.

## Summary
S3 tools accepted `region` as a free `z.string()`. A value like `us-east-1` reached `S3Client` construction, did a real DNS/TLS attempt, and was not an `S3ServiceException`, so `handleS3` rethrew it uncaught. Audit Trail already had `z.enum(["fr-par", "nl-ams", "pl-waw"])`.

- New `src/scwRegion.ts` exporting `scwRegionSchema`.
- S3 `region` fields in `buckets.ts`, `bucketPolicies.ts`, `bucketConfig.ts`, `objects.ts` now use it.
- `auditRegionSchema` reuses the same enum so there is one source of truth.
- `SCW_DEFAULT_REGION` / `getS3Client` left unchanged (out of issue scope).

## Test plan
- [x] `npm run build` (`tsc`) passes on the stacked tip
- [ ] Invalid-region Zod rejection not live-tested here