### PR TITLE
fix(iam): warn that update_user tags replace the full list (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here.
 - `scaleway_audit_create_export_job` now requires `confirm=true` because creation immediately backfills ~6 days of real audit events into the destination bucket, and `scaleway_audit_delete_export_job` does not remove those objects (#27).
 - Validate S3 `region` as `fr-par`/`nl-ams`/`pl-waw` instead of a free-form string, so a bad region fails at schema validation rather than an uncaught DNS/TLS error (#28).
 - `scaleway_s3_get_object` fails fast when the object exceeds `MAX_GET_OBJECT_BYTES` (default 5 MB) instead of buffering it into memory (#29).
+- Warn that `scaleway_iam_update_user` tags replace the full list (#30)
 
 ## 0.1.1
 

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -115,7 +115,18 @@ export function registerUsers(server: McpServer, config: Config) {
         "Update a User's mutable profile fields (tags; name/email where the API allows - invalid fields are rejected with the API's own validation message). Only passed fields change.",
       inputSchema: {
         user_id: z.string().uuid(),
-        tags: z.array(z.string()).optional(),
+        tags: z
+          .array(z.string())
+          .max(10)
+          .optional()
+          .describe(
+            "Structured metadata, max 10. Locked vocabulary in this org: 'env={prod|dev|local|ci|shared}', " +
+              "'access={ro|rw|admin|full}', 'owner=<team-or-tool>', 'issue=<n>', 'managed-by={mcp|manual|terraform}'. " +
+              "Use '=' as the separator, not ':' - Scaleway's tags API rejects colons " +
+              "(validated against ^[a-zA-Z0-9._\\-/=+@ ]+$, confirmed empirically 2026-08-18). " +
+              "REPLACES the full tag list (same semantics as scaleway_s3_put_bucket_policy replacing the whole policy " +
+              "document) - pass the complete set you want, not just the ones you're adding.",
+          ),
         first_name: z.string().optional(),
         last_name: z.string().optional(),
       },


### PR DESCRIPTION
Closes #30.

**Stack:** 6/7. Base is `fix/29-get-object-size-cap`.

## Summary
`scaleway_iam_update_user`'s `tags` field had no replace-not-merge warning. `update_application` and `update_policy` already warn that passing `tags` replaces the complete set on the same IAM `PATCH .../{id}` shape.

- Copy the sibling warning onto `update_user` tags: locked vocabulary, `=` vs `:`, max 10, and "REPLACES the full tag list — pass the complete set you want".
- Tool-level "Only passed fields change" is unchanged.

## Test plan
- [x] `npm run build` (`tsc`) passes on the stacked tip