### PR TITLE
fix(s3): mark put_bucket_tagging as destructive (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here.
 - Validate S3 `region` as `fr-par`/`nl-ams`/`pl-waw` instead of a free-form string, so a bad region fails at schema validation rather than an uncaught DNS/TLS error (#28).
 - `scaleway_s3_get_object` fails fast when the object exceeds `MAX_GET_OBJECT_BYTES` (default 5 MB) instead of buffering it into memory (#29).
 - Warn that `scaleway_iam_update_user` tags replace the full list (#30)
+- Mark `scaleway_s3_put_bucket_tagging` as `destructiveHint: true` so MCP clients confirm the full-replace tag write (#31).
 
 ## 0.1.1
 

--- a/src/tools/bucketConfig.ts
+++ b/src/tools/bucketConfig.ts
@@ -69,7 +69,7 @@ export function registerBucketConfig(server: McpServer, config: Config) {
         region: regionField,
         tags: z.array(z.object({ key: z.string().min(1), value: z.string() })).min(1).describe("The COMPLETE tag set to apply."),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     },
     async ({ bucket, region, tags }) =>
       handleS3(async () => {


### PR DESCRIPTION
Closes #31.

**Stack:** 7/7. Base is `fix/30-update-user-tags-warning`. Top of the stack.

## Summary
`scaleway_s3_put_object_tags` is `destructiveHint: true`. Sibling `scaleway_s3_put_bucket_tagging` does the same full-replace-no-confirm tag write but was `destructiveHint: false`. MCP clients use this hint for confirmation.

- Flip `put_bucket_tagging` to `destructiveHint: true`.
- No confirm field added (out of issue scope). `put_object_tags` already correct.

## Test plan
- [x] `npm run build` (`tsc`) passes on the stacked tip