### PR TITLE
fix(security): avoid logging password update response

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -489,7 +489,8 @@ const bogusPassword = await client.callTool({
   arguments: { user_id: bogusId, password: "Xy9!mQ2#kL7%pR4z", confirm: true },
 });
 if (!bogusPassword.isError || !text(bogusPassword).includes("resource is not found")) {
-  console.error(`FAILED: update_user_password did not surface the expected bogus-id 404 (password body likely not sent): ${text(bogusPassword).slice(0, 100)}`);
+  // Do not render the API response: it can include the password supplied above.
+  console.error("FAILED: update_user_password did not surface the expected bogus-id 404 (password body likely not sent)");
   process.exit(1);
 }
 console.log("api err ok (password bogus id): password reached the API and the id lookup 404'd, as expected");


### PR DESCRIPTION
## Summary

- Avoid rendering the failed password-update API response in the smoke test.
- Prevent a response that may contain the supplied password from reaching logs.

## Root cause

The negative smoke-test assertion included the raw API response in its failure message. CodeQL correctly identified that response as potentially containing the password sent to the API.

## Validation

- `npm ci`
- `npm run build`
