### PR TITLE
fix: address review of #33–#39 (get_object HEAD-first, paged lockout read)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,12 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-
-- `scaleway_iam_set_policy_rules` now requires `confirm=true` and refuses a full-replace that would drop `IAMPolicyManager`/`IAMApplicationManager` from a policy that currently grants them, so a stale or incomplete rules array cannot permanently lock this credential out of IAM (issue #25).
+- `scaleway_iam_set_policy_rules` now requires `confirm=true` and refuses a full-replace that would drop `IAMPolicyManager`/`IAMApplicationManager` from a policy that currently grants them, so a stale or incomplete rules array cannot permanently lock this credential out of IAM (issue #25). The lockout read (and `list_policy_rules`) pages via `iamListAll` so a rule past page 1 cannot slip the guard.
 - `scaleway_s3_generate_presigned_url`: `operation: "put"` now requires `confirm=true` and the tool is no longer annotated `readOnlyHint` - a PUT URL exports a time-limited unauthenticated write capability outside the MCP boundary (issue #26).
 - `scaleway_audit_create_export_job` now requires `confirm=true` because creation immediately backfills ~6 days of real audit events into the destination bucket, and `scaleway_audit_delete_export_job` does not remove those objects (#27).
-- Validate S3 `region` as `fr-par`/`nl-ams`/`pl-waw` instead of a free-form string, so a bad region fails at schema validation rather than an uncaught DNS/TLS error (#28).
-- `scaleway_s3_get_object` fails fast when the object exceeds `MAX_GET_OBJECT_BYTES` (default 5 MB) instead of buffering it into memory (#29).
-- Warn that `scaleway_iam_update_user` tags replace the full list (#30)
+- Validate S3 `region` as `fr-par`/`nl-ams`/`pl-waw` instead of a free-form string, so a bad region fails at schema validation rather than an uncaught DNS/TLS error (#28). `SCW_DEFAULT_REGION` uses the same enum, so a bad env value fails at startup instead of on the first S3 call.
+- `scaleway_s3_get_object` HEADs first and refuses over `MAX_GET_OBJECT_BYTES` (default 5 MB) before opening the object body (#29).
+- `scaleway_iam_update_user`'s `tags` field now warns that the array replaces the full list, not a merge (#30).
 - Mark `scaleway_s3_put_bucket_tagging` as `destructiveHint: true` so MCP clients confirm the full-replace tag write (#31).
 
 ## 0.1.1

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -209,9 +209,9 @@ creating a job against an empty throwaway bucket produced six daily log objects
 *past* several days, not just events going forward. `scaleway_audit_delete_export_job` explicitly
 does not delete already-exported objects (by design, matching every other delete tool in this
 server), so a bucket created purely to test an export job will NOT be empty afterward -
-`scaleway_s3_delete_bucket` fails `BucketNotEmpty` until those objects are removed, which needs a
-raw S3 call since object-level operations are out of this server's scope. The tool now requires
-`confirm=true`.
+`scaleway_s3_delete_bucket` fails `BucketNotEmpty` until those objects are removed - list them with
+`scaleway_s3_list_objects` and delete with `scaleway_s3_delete_objects` (confirm-gated). The tool
+now requires `confirm=true`.
 
 ## Preconfigured alert rules start all-disabled, and the two write tools differ in blast radius
 

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -454,6 +454,7 @@ for (const [name, args, label] of [
   ["scaleway_iam_update_user_password", { user_id: bogusId, password: "Xy9!mQ2#kL7%pR4z" }, "password without confirm"],
   ["scaleway_iam_update_user_username", { user_id: bogusId, new_username: "probe_xyz" }, "username without confirm"],
   ["scaleway_iam_delete_user_mfa_otp", { user_id: bogusId }, "mfa delete without confirm"],
+  ["scaleway_iam_set_policy_rules", { policy_id: bogusId, rules: [{ permission_set_names: ["IAMPolicyManager"], organization_id: bogusId }] }, "set_policy_rules without confirm"],
 ]) {
   const res = await client.callTool({ name, arguments: args });
   if (!res.isError) { console.error(`FAILED at "${label}": expected schema rejection, got success`); process.exit(1); }
@@ -574,6 +575,7 @@ for (const [name, args, label] of [
   ["scaleway_iam_enable_scim", {}, "enable_scim without confirm"],
   ["scaleway_iam_disable_scim", {}, "disable_scim without confirm"],
   ["scaleway_iam_delete_jwt", { jti: bogusId }, "delete_jwt without confirm"],
+  ["scaleway_audit_create_export_job", { name: "probe", bucket: "probe-bucket" }, "create_export_job without confirm"],
 ]) {
   const res = await client.callTool({ name, arguments: args });
   if (!res.isError) { console.error(`FAILED at "${label}": expected schema rejection, got success`); process.exit(1); }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
+import { scwRegionSchema } from "./scwRegion.js";
 
 const configSchema = z.object({
   SCW_SECRET_KEY: z.string().min(1, "SCW_SECRET_KEY is required"),
   SCW_ACCESS_KEY: z.string().min(1, "SCW_ACCESS_KEY is required"),
   SCW_ORGANIZATION_ID: z.string().min(1, "SCW_ORGANIZATION_ID is required"),
   SCW_PROJECT_ID: z.string().min(1, "SCW_PROJECT_ID is required"),
-  SCW_DEFAULT_REGION: z.string().default("fr-par"),
+  SCW_DEFAULT_REGION: scwRegionSchema.default("fr-par"),
   MAX_OUTPUT_CHARS: z.coerce.number().int().min(1000).default(25000),
   // Base64 in a JSON tool call/result roughly quadruples wire size vs. raw bytes (encode + the
   // surrounding JSON string escaping), so this bounds the DECODED byte size, not the payload the

--- a/src/tools/objects.ts
+++ b/src/tools/objects.ts
@@ -178,12 +178,8 @@ export function registerObjects(server: McpServer, config: Config) {
     async ({ bucket, region, key }) =>
       handleS3(async () => {
         const client = getS3Client(config, region);
-        const res = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
-        let sizeBytes = res.ContentLength;
-        if (sizeBytes === undefined) {
-          const head = await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
-          sizeBytes = head.ContentLength;
-        }
+        const head = await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+        const sizeBytes = head.ContentLength;
         if (sizeBytes === undefined) {
           return toolError(
             "Object size could not be determined. Use scaleway_s3_generate_presigned_url or scaleway_s3_head_object.",
@@ -192,6 +188,15 @@ export function registerObjects(server: McpServer, config: Config) {
         if (sizeBytes > config.MAX_GET_OBJECT_BYTES) {
           return toolError(
             `Object is ${sizeBytes} bytes, over the ${config.MAX_GET_OBJECT_BYTES}-byte ceiling (MAX_GET_OBJECT_BYTES). ` +
+              "Use scaleway_s3_generate_presigned_url instead.",
+          );
+        }
+        const res = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+        if (res.ContentLength !== undefined && res.ContentLength > config.MAX_GET_OBJECT_BYTES) {
+          const body = res.Body as { destroy?: () => void } | undefined;
+          body?.destroy?.();
+          return toolError(
+            `Object is ${res.ContentLength} bytes, over the ${config.MAX_GET_OBJECT_BYTES}-byte ceiling (MAX_GET_OBJECT_BYTES). ` +
               "Use scaleway_s3_generate_presigned_url instead.",
           );
         }

--- a/src/tools/policies.ts
+++ b/src/tools/policies.ts
@@ -259,8 +259,8 @@ export function registerPolicies(server: McpServer, config: Config) {
     },
     async ({ policy_id }) =>
       withIamErrorHandling(async () => {
-        const data = await iamRequest<{ rules: Rule[]; total_count: number }>(config, "GET", `/rules?policy_id=${policy_id}`);
-        return toolJsonResult(data, config.MAX_OUTPUT_CHARS);
+        const rules = await iamListAll<Rule>(config, `/rules?policy_id=${policy_id}`, "rules");
+        return toolJsonResult({ total_count: rules.length, rules }, config.MAX_OUTPUT_CHARS);
       }),
   );
 
@@ -282,8 +282,8 @@ export function registerPolicies(server: McpServer, config: Config) {
     },
     async ({ policy_id, rules, confirm }) =>
       withIamErrorHandling(async () => {
-        const current = await iamRequest<{ rules: Rule[]; total_count: number }>(config, "GET", `/rules?policy_id=${policy_id}`);
-        const currentSets = new Set((current.rules ?? []).flatMap((r) => r.permission_set_names));
+        const currentRules = await iamListAll<Rule>(config, `/rules?policy_id=${policy_id}`, "rules");
+        const currentSets = new Set(currentRules.flatMap((r) => r.permission_set_names));
         const incomingSets = new Set(rules.flatMap((r) => r.permission_set_names));
         const droppingPolicyManager = currentSets.has("IAMPolicyManager") && !incomingSets.has("IAMPolicyManager");
         const droppingApplicationManager =


### PR DESCRIPTION
Follow-up to the post-merge review of #33–#39. Inline comments are on those PRs.

## Fixes

- **#37 / objects.ts:** `get_object` HEADs first and refuses over `MAX_GET_OBJECT_BYTES` before `GetObject`. If Get still reports oversize (TOCTOU), destroy the body and error — do not `bodyToBuffer`.
- **#33 / policies.ts:** lockout read and `list_policy_rules` use `iamListAll` so a rule past page 1 cannot slip the `IAMPolicyManager` / `IAMApplicationManager` guard.
- **#36 / config.ts:** `SCW_DEFAULT_REGION` is the same `fr-par`/`nl-ams`/`pl-waw` enum as tool `region`, so a bad env fails at `loadConfig()` instead of an uncaught DNS/TLS error.
- **#34 / smoke-test:** missing-`confirm` rejection for `set_policy_rules` and `create_export_job`.
- **#35 / gotchas.md:** export-job residue cleanup points at `list_objects` / `delete_objects`, not “raw S3 / out of scope.”
- **#33 / #38 CHANGELOG:** drop the spare Unreleased blank line; rewrite the #30 bullet as a complete sentence.

## Test plan
- [x] `npm run build` (`tsc`) passes
- [ ] Live smoke-test not run here (needs Scaleway credentials)