### PR TITLE
fix(iam): strip secret_key from list/update api key results (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+
 - `scaleway_iam_delete_policy` now GETs current rules first and refuses the delete if the policy currently grants `IAMPolicyManager`/`IAMApplicationManager`, even with `confirm=true` (issue #43).
 - `scaleway_iam_delete_application`/`scaleway_iam_delete_group` now refuse (even with `confirm=true`) when a policy attached to that Application/Group currently grants `IAMPolicyManager`/`IAMApplicationManager`: Scaleway detaches (does not delete) a policy when its principal is deleted, so this was a second, unguarded path to the same lockout `delete_policy` refuses (issue #43 follow-up, found in review). `scripts/smoke-test.mjs`'s group_id-principal cross-check policy no longer uses `IAMPolicyManager` for this reason - it was silently failing to clean itself up under the new `delete_policy` guard.
 - `scaleway_iam_set_policy_rules` lockout now requires `IAMPolicyManager`/`IAMApplicationManager` to remain on an org-scoped rule (`organization_id`); keeping the name on a `project_ids` rule no longer bypasses the guard (#44). `ruleSchema` enforces exactly one of `project_ids`/`organization_id`.
+- `scaleway_iam_list_api_keys` and `scaleway_iam_update_api_key` allow-list API key fields and omit `secret_key`, so a list/update response cannot leak a secret into the tool result (#45). `create_api_key` still returns the raw key (the secret is only visible at creation).
 - `scaleway_iam_set_policy_rules` now requires `confirm=true` and refuses a full-replace that would drop `IAMPolicyManager`/`IAMApplicationManager` from a policy that currently grants them, so a stale or incomplete rules array cannot permanently lock this credential out of IAM (issue #25). The lockout read (and `list_policy_rules`) pages via `iamListAll` so a rule past page 1 cannot slip the guard.
 - `scaleway_s3_generate_presigned_url`: `operation: "put"` now requires `confirm=true` and the tool is no longer annotated `readOnlyHint` - a PUT URL exports a time-limited unauthenticated write capability outside the MCP boundary (issue #26).
 - `scaleway_audit_create_export_job` now requires `confirm=true` because creation immediately backfills ~6 days of real audit events into the destination bucket, and `scaleway_audit_delete_export_job` does not remove those objects (#27).

--- a/src/tools/apiKeys.ts
+++ b/src/tools/apiKeys.ts
@@ -66,6 +66,21 @@ const deleteSchema = {
   confirm: z.literal(true).describe("Must be explicitly true. Deletion is immediate and irreversible - anything using this key stops authenticating right away."),
 };
 
+/** Allow-list for list/update results. Omits `secret_key` (only returned at creation). */
+function apiKeyView(key: ApiKey) {
+  return {
+    access_key: key.access_key,
+    application_id: key.application_id ?? null,
+    user_id: key.user_id ?? null,
+    description: key.description,
+    created_at: key.created_at,
+    updated_at: key.updated_at,
+    expires_at: key.expires_at ?? null,
+    default_project_id: key.default_project_id ?? null,
+    creation_ip: key.creation_ip,
+  };
+}
+
 export function registerApiKeys(server: McpServer, config: Config) {
   server.registerTool(
     "scaleway_iam_create_api_key",
@@ -113,7 +128,7 @@ export function registerApiKeys(server: McpServer, config: Config) {
           expires_at,
           default_project_id,
         });
-        return toolJsonResult(key, config.MAX_OUTPUT_CHARS);
+        return toolJsonResult(apiKeyView(key), config.MAX_OUTPUT_CHARS);
       }),
   );
 
@@ -130,7 +145,7 @@ export function registerApiKeys(server: McpServer, config: Config) {
         const params = new URLSearchParams({ organization_id: config.SCW_ORGANIZATION_ID });
         if (application_id) params.set("application_id", application_id);
         const all = await iamListAll<ApiKey>(config, `/api-keys?${params}`, "api_keys");
-        return toolJsonResult({ total_count: all.length, count: all.length, api_keys: all }, config.MAX_OUTPUT_CHARS);
+        return toolJsonResult({ total_count: all.length, count: all.length, api_keys: all.map(apiKeyView) }, config.MAX_OUTPUT_CHARS);
       }),
   );
 


### PR DESCRIPTION
Closes #45.

**Stack:** 3/9. Base is `fix/44-set-policy-rules-scope`.

## Summary
`list_api_keys` / `update_api_key` passed the raw API object through, unlike `list_scim_tokens` / users / ssh keys.

- `apiKeyView` allow-lists public fields and omits `secret_key`.
- `create_api_key` still returns the raw key (secret is only visible at creation).

## Test plan
- [x] `npm run build` (`tsc`) on the stacked tip