### PR TITLE
fix(s3): confirm-gate put_bucket_policy (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented here.
 - `scaleway_s3_get_object` HEADs first and refuses over `MAX_GET_OBJECT_BYTES` (default 5 MB) before opening the object body (#29).
 - `scaleway_iam_update_user`'s `tags` field now warns that the array replaces the full list, not a merge (#30).
 - Mark `scaleway_s3_put_bucket_tagging` as `destructiveHint: true` so MCP clients confirm the full-replace tag write (#31).
+- `scaleway_s3_put_bucket_policy` now requires `confirm=true` because it replaces the entire bucket policy in one shot and can grant `Principal *` or drop the caller's own access (#46).
 
 ## 0.1.1
 

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -384,6 +384,7 @@ try {
   if (vis0.visibility !== "private") { console.error("FAILED: new bucket not private"); process.exit(1); }
   await expectError("scaleway_s3_set_bucket_visibility", { bucket: cfgBucket, visibility: "public-read" }, "public without confirm rejected");
   await expectError("scaleway_s3_generate_presigned_url", { bucket: cfgBucket, key: "probe.txt", operation: "put" }, "presigned put without confirm rejected");
+  await expectError("scaleway_s3_put_bucket_policy", { bucket: cfgBucket, policy_json: "{\"Version\":\"2023-04-17\",\"Statement\":[]}" }, "put_bucket_policy without confirm rejected");
   console.log("visibility public:", text(await client.callTool({ name: "scaleway_s3_set_bucket_visibility", arguments: { bucket: cfgBucket, visibility: "public-read", confirm: true } })).slice(0, 80));
   const vis1 = expectJson(await client.callTool({ name: "scaleway_s3_get_bucket_visibility", arguments: { bucket: cfgBucket } }), "get visibility public");
   if (vis1.visibility !== "public") { console.error("FAILED: visibility not public after set"); process.exit(1); }

--- a/src/tools/bucketPolicies.ts
+++ b/src/tools/bucketPolicies.ts
@@ -36,6 +36,12 @@ const putSchema = {
         "the relevant permission sets is required in addition to this bucket policy - a Bucket Policy alone is " +
         "not sufficient on Scaleway.",
     ),
+  confirm: z
+    .literal(true)
+    .describe(
+      "Must be explicitly true. This replaces the entire bucket policy - a document granting Principal * or " +
+        "omitting the caller's own access takes effect immediately.",
+    ),
 };
 
 const deleteSchema = {
@@ -76,7 +82,7 @@ export function registerBucketPolicies(server: McpServer, config: Config) {
     {
       title: "Set Scaleway Bucket Policy",
       description:
-        "Replace a bucket's entire Bucket Policy with the given JSON document. This is the bucket-scoped half of " +
+        "Replace a bucket's entire Bucket Policy with the given JSON document. Requires confirm=true. This is the bucket-scoped half of " +
         "access control - see scaleway_iam_create_policy's description for why both an IAM Policy and a Bucket " +
         "Policy are needed together. Recommended safety net: include a statement granting the bucket owner's own " +
         "user_id full access (mirrors the console's 'Maintain access to bucket' checkbox) so a mistake here can " +
@@ -84,7 +90,7 @@ export function registerBucketPolicies(server: McpServer, config: Config) {
       inputSchema: putSchema,
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     },
-    async ({ bucket, region, policy_json }) => {
+    async ({ bucket, region, policy_json, confirm }) => {
       if (!isValidJson(policy_json)) {
         return toolError("policy_json is not valid JSON - check for a missing/extra brace or comma before sending.");
       }


### PR DESCRIPTION
Closes #46.

**Stack:** 4/9. Base is `fix/45-api-keys-strip-secret`.

## Summary
`put_bucket_policy` is a full-replace of bucket access control with no `confirm`, unlike `delete_bucket_policy` and `set_bucket_visibility`.

- `confirm: true` on put.
- Smoke-test: put-without-confirm `expectError`.

## Test plan
- [x] `npm run build` (`tsc`) on the stacked tip