### PR TITLE
fix: omit structuredContent when over MAX_OUTPUT_CHARS (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ All notable changes to this project are documented here.
 - `scaleway_s3_get_object` HEADs first and refuses over `MAX_GET_OBJECT_BYTES` (default 5 MB) before opening the object body (#29).
 - `scaleway_iam_update_user`'s `tags` field now warns that the array replaces the full list, not a merge (#30).
 - Mark `scaleway_s3_put_bucket_tagging` as `destructiveHint: true` so MCP clients confirm the full-replace tag write (#31).
+
 - `scaleway_s3_put_bucket_policy` now requires `confirm=true` because it replaces the entire bucket policy in one shot and can grant `Principal *` or drop the caller's own access (#46).
+- `toolJsonResult` omits `structuredContent` when the untruncated pretty JSON exceeds `MAX_OUTPUT_CHARS`, so large list responses are actually bounded by the truncated text (#47).
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project are documented here.
 - Mark `scaleway_s3_put_bucket_tagging` as `destructiveHint: true` so MCP clients confirm the full-replace tag write (#31).
 
 - `scaleway_s3_put_bucket_policy` now requires `confirm=true` because it replaces the entire bucket policy in one shot and can grant `Principal *` or drop the caller's own access (#46).
-- `toolJsonResult` omits `structuredContent` when the untruncated pretty JSON exceeds `MAX_OUTPUT_CHARS`, so large list responses are actually bounded by the truncated text (#47).
+- `toolJsonResult` replaces `structuredContent` with an explicit `{ truncated: true, note }` marker when the untruncated pretty JSON exceeds `MAX_OUTPUT_CHARS`, so large list responses are actually bounded by the truncated text and a caller reading `structuredContent` gets an unambiguous signal instead of a silently missing field (#47).
 
 ## 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Environment variables (see `.env.example`):
 | `SCW_ORGANIZATION_ID` | yes | Organization these operations run in. |
 | `SCW_PROJECT_ID` | yes | Default Project (used as `default_project_id` when creating API keys, and wherever a Project id is needed but not explicitly passed). |
 | `SCW_DEFAULT_REGION` | no (default `fr-par`) | Region for Bucket Policy calls when a tool call doesn't specify one. |
-| `MAX_OUTPUT_CHARS` | no (default `25000`) | Truncation limit for tool responses. |
+| `MAX_OUTPUT_CHARS` | no (default `25000`) | Truncation limit for tool response text; structuredContent is omitted when the untruncated JSON exceeds the ceiling. |
 | `MAX_PUT_OBJECT_BYTES` | no (default `5000000`) | Decoded-size ceiling for `scaleway_s3_put_object` - single-part only, multipart is out of scope. |
 | `MAX_GET_OBJECT_BYTES` | no (default `5000000`) | Decoded-size ceiling for `scaleway_s3_get_object` - larger objects should use `scaleway_s3_generate_presigned_url`. |
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Environment variables (see `.env.example`):
 | `SCW_ORGANIZATION_ID` | yes | Organization these operations run in. |
 | `SCW_PROJECT_ID` | yes | Default Project (used as `default_project_id` when creating API keys, and wherever a Project id is needed but not explicitly passed). |
 | `SCW_DEFAULT_REGION` | no (default `fr-par`) | Region for Bucket Policy calls when a tool call doesn't specify one. |
-| `MAX_OUTPUT_CHARS` | no (default `25000`) | Truncation limit for tool response text; structuredContent is omitted when the untruncated JSON exceeds the ceiling. |
+| `MAX_OUTPUT_CHARS` | no (default `25000`) | Truncation limit for tool response text; `structuredContent` is replaced with a `{ truncated: true, note }` marker when the untruncated JSON exceeds the ceiling. |
 | `MAX_PUT_OBJECT_BYTES` | no (default `5000000`) | Decoded-size ceiling for `scaleway_s3_put_object` - single-part only, multipart is out of scope. |
 | `MAX_GET_OBJECT_BYTES` | no (default `5000000`) | Decoded-size ceiling for `scaleway_s3_get_object` - larger objects should use `scaleway_s3_generate_presigned_url`. |
 

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -745,5 +745,43 @@ const groupsAfter = expectJson(await client.callTool({ name: "scaleway_iam_list_
 if (groupsAfter.groups.some((g) => g.id === createdGroupId)) throw new Error("throwaway group still present after delete");
 console.log(`verify gone: throwaway group no longer in list_groups (back to ${groupsAfter.total_count}, zero residue)`);
 
+console.log("\n=== OUTPUT TRUNCATION (issue #47): structuredContent replaced with a marker over MAX_OUTPUT_CHARS ===");
+{
+  // Separate short-lived client/server pair with a deliberately tiny MAX_OUTPUT_CHARS, so any
+  // JSON-returning tool call is guaranteed to exceed the ceiling regardless of live account size.
+  const tinyTransport = new StdioClientTransport({
+    command: "node",
+    args: [join(repoRoot, "dist/index.js")],
+    env: {
+      SCW_ACCESS_KEY: creds.SCW_ACCESS_KEY,
+      SCW_SECRET_KEY: creds.SCW_SECRET_KEY,
+      SCW_ORGANIZATION_ID: creds.SCW_ORGANIZATION_ID,
+      SCW_PROJECT_ID: creds.SCW_PROJECT_ID,
+      MAX_OUTPUT_CHARS: "10",
+    },
+  });
+  const tinyClient = new Client({ name: "smoke-test-client-tiny-output", version: "0.0.1" });
+  await tinyClient.connect(tinyTransport);
+  try {
+    const res = await tinyClient.callTool({ name: "scaleway_iam_list_applications", arguments: {} });
+    if (res.isError) { console.error("FAILED at truncation probe:", text(res)); process.exit(1); }
+    if (!text(res).includes("[... truncated")) {
+      console.error("FAILED: text content missing truncation notice:", text(res).slice(0, 200));
+      process.exit(1);
+    }
+    if (res.structuredContent?.truncated !== true) {
+      console.error("FAILED: structuredContent is not the { truncated: true } marker:", JSON.stringify(res.structuredContent));
+      process.exit(1);
+    }
+    console.log("guard ok (over MAX_OUTPUT_CHARS): text carries a truncation notice, structuredContent =", JSON.stringify(res.structuredContent));
+  } finally {
+    await tinyClient.close();
+  }
+}
+// Non-truncated path stays a plain passthrough: the very first call this script made
+// (list_applications, filtered) returned real structuredContent under the default 25000 ceiling.
+if (apps.structuredContent?.truncated) { console.error("FAILED: default-ceiling call was unexpectedly marked truncated"); process.exit(1); }
+console.log("guard ok (under MAX_OUTPUT_CHARS): structuredContent is the real data, no truncation marker");
+
 await client.close();
 console.log("\nDONE - full read/write/delete lifecycle verified (applications, API keys, buckets, objects, ssh keys, groups)");

--- a/src/output.ts
+++ b/src/output.ts
@@ -14,12 +14,17 @@ export function toolResult(text: string, maxChars: number): CallToolResult {
   };
 }
 
-/** Build a successful CallToolResult carrying structured JSON, mirrored as text. */
+/** Build a successful CallToolResult carrying structured JSON, mirrored as text.
+ * structuredContent is omitted when the untruncated JSON exceeds maxChars. */
 export function toolJsonResult(data: unknown, maxChars: number): CallToolResult {
-  return {
-    content: [{ type: "text", text: truncate(JSON.stringify(data, null, 2), maxChars) }],
-    structuredContent: data as Record<string, unknown>,
+  const text = JSON.stringify(data, null, 2);
+  const result: CallToolResult = {
+    content: [{ type: "text", text: truncate(text, maxChars) }],
   };
+  if (text.length <= maxChars) {
+    result.structuredContent = data as Record<string, unknown>;
+  }
+  return result;
 }
 
 /** Build an error CallToolResult. */

--- a/src/output.ts
+++ b/src/output.ts
@@ -15,16 +15,23 @@ export function toolResult(text: string, maxChars: number): CallToolResult {
 }
 
 /** Build a successful CallToolResult carrying structured JSON, mirrored as text.
- * structuredContent is omitted when the untruncated JSON exceeds maxChars. */
+ * When the untruncated JSON exceeds maxChars, structuredContent carries a truncation
+ * marker instead of the real data - never the field silently missing - so a caller
+ * that reads structuredContent (rather than parsing the text mirror) gets an explicit,
+ * typed signal that it was cut, instead of something indistinguishable from "no
+ * structured content for this tool". */
 export function toolJsonResult(data: unknown, maxChars: number): CallToolResult {
   const text = JSON.stringify(data, null, 2);
-  const result: CallToolResult = {
+  const truncated = text.length > maxChars;
+  return {
     content: [{ type: "text", text: truncate(text, maxChars) }],
+    structuredContent: truncated
+      ? {
+          truncated: true,
+          note: `Response exceeds MAX_OUTPUT_CHARS (${maxChars} chars) - structuredContent omitted; see the truncated JSON in the text content instead.`,
+        }
+      : (data as Record<string, unknown>),
   };
-  if (text.length <= maxChars) {
-    result.structuredContent = data as Record<string, unknown>;
-  }
-  return result;
 }
 
 /** Build an error CallToolResult. */


### PR DESCRIPTION
Closes #47.

**Stack:** 5/9. Base is `fix/46-put-bucket-policy-confirm`.

## Summary
`toolJsonResult` truncated only the text mirror. `structuredContent` always carried the full object, so `MAX_OUTPUT_CHARS` was cosmetic.

- Include `structuredContent` only when untruncated pretty JSON fits under the ceiling.
- Over the ceiling, omit it so the wire payload is the truncated text.

## Test plan
- [x] `npm run build` (`tsc`) on the stacked tip