### PR TITLE
fix: validate SCW_ORGANIZATION_ID and SCW_PROJECT_ID as UUIDs (#51)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,8 +4,8 @@ import { scwRegionSchema } from "./scwRegion.js";
 const configSchema = z.object({
   SCW_SECRET_KEY: z.string().min(1, "SCW_SECRET_KEY is required"),
   SCW_ACCESS_KEY: z.string().min(1, "SCW_ACCESS_KEY is required"),
-  SCW_ORGANIZATION_ID: z.string().min(1, "SCW_ORGANIZATION_ID is required"),
-  SCW_PROJECT_ID: z.string().min(1, "SCW_PROJECT_ID is required"),
+  SCW_ORGANIZATION_ID: z.string().uuid("SCW_ORGANIZATION_ID must be a valid UUID"),
+  SCW_PROJECT_ID: z.string().uuid("SCW_PROJECT_ID must be a valid UUID"),
   SCW_DEFAULT_REGION: scwRegionSchema.default("fr-par"),
   MAX_OUTPUT_CHARS: z.coerce.number().int().min(1000).default(25000),
   // Base64 in a JSON tool call/result roughly quadruples wire size vs. raw bytes (encode + the


### PR DESCRIPTION
## Summary
Tightens the Zod schema for `SCW_ORGANIZATION_ID` and `SCW_PROJECT_ID` from non-empty strings to UUIDs, matching every other ID field in the codebase.

## Changes
- Changed `z.string().min(1)` to `z.string().uuid()` for both env vars
- Provides clear error messages: "must be a valid UUID"

## Why
Every per-call tool-input ID field in the codebase is now `.uuid()`-or-regex-constrained, but these two env-var-sourced config values — interpolated into essentially every IAM request path/query — were validated only as non-empty strings. Tightening to `.uuid()` is a one-line, zero-risk fix consistent with the rest of the codebase's philosophy of failing fast at config/schema time.

Closes #51