### PR TITLE
fix(iam): refuse to delete this server's own operating credential/Application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- `scaleway_iam_delete_api_key` now refuses (even with `confirm=true`) to delete THIS server's own operating credential (the key matching `SCW_ACCESS_KEY`), and `scaleway_iam_delete_application` now refuses to delete the Application that owns it - deleting either would revoke every capability this server has (not just IAM management, the class of lockout #43 covers) with no way to undo it through this server afterward (#63).
 
 - `scaleway_iam_delete_policy` now GETs current rules first and refuses the delete if the policy currently grants `IAMPolicyManager`/`IAMApplicationManager`, even with `confirm=true` (issue #43).
 - `scaleway_iam_delete_application`/`scaleway_iam_delete_group` now refuse (even with `confirm=true`) when a policy attached to that Application/Group currently grants `IAMPolicyManager`/`IAMApplicationManager`: Scaleway detaches (does not delete) a policy when its principal is deleted, so this was a second, unguarded path to the same lockout `delete_policy` refuses (issue #43 follow-up, found in review). `scripts/smoke-test.mjs`'s group_id-principal cross-check policy no longer uses `IAMPolicyManager` for this reason - it was silently failing to clean itself up under the new `delete_policy` guard.

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -70,6 +70,34 @@ console.log("\n=== scaleway_iam_list_policies (filter: scaleway-ops app) ===");
 const policies = await client.callTool({ name: "scaleway_iam_list_policies", arguments: { application_id: appId } });
 console.log(text(policies).slice(0, 600));
 
+console.log("\n=== SELF-LOCKOUT GUARD (issue #63): the server's own operating credential/Application cannot be deleted through itself ===");
+// Resolve the real access_key -> application_id relationship from the API rather than trusting the
+// name_filter above - this is the actual credential authenticating this very client connection.
+const allKeysUnfiltered = expectJson(await client.callTool({ name: "scaleway_iam_list_api_keys", arguments: {} }), "list_api_keys (unfiltered, resolve own key)");
+const ownKeyEntry = allKeysUnfiltered.api_keys.find((k) => k.access_key === creds.SCW_ACCESS_KEY);
+if (!ownKeyEntry) {
+  console.error("FAILED: could not find this server's own operating key (SCW_ACCESS_KEY) in list_api_keys - cannot verify the self-lockout guard");
+  process.exit(1);
+}
+console.log("own operating key found:", ownKeyEntry.access_key, "-> application_id", ownKeyEntry.application_id);
+
+// The dangerous case, proven live and for real - same pattern as the real-OWNER delete_user guard
+// below: the tool itself must refuse before the request ever reaches the API, so a bug here would
+// never actually delete anything (the check runs before any DELETE call in both handlers).
+const selfKeyDelete = await client.callTool({ name: "scaleway_iam_delete_api_key", arguments: { access_key: creds.SCW_ACCESS_KEY, confirm: true } });
+if (!selfKeyDelete.isError || !text(selfKeyDelete).includes("own operating credential")) {
+  console.error("FAILED: delete_api_key on the server's own operating key was not refused:", text(selfKeyDelete));
+  process.exit(1);
+}
+console.log("guard ok (own operating key delete refused):", text(selfKeyDelete).slice(0, 120));
+
+const selfAppDelete = await client.callTool({ name: "scaleway_iam_delete_application", arguments: { application_id: ownKeyEntry.application_id, confirm: true } });
+if (!selfAppDelete.isError || !text(selfAppDelete).includes("own operating")) {
+  console.error("FAILED: delete_application on the server's own Application was not refused:", text(selfAppDelete));
+  process.exit(1);
+}
+console.log("guard ok (own Application delete refused):", text(selfAppDelete).slice(0, 120));
+
 console.log("\n=== WRITE PATH: create -> get -> delete a throwaway Application ===");
 // Unique name per run: Scaleway's name-uniqueness check appears to lag briefly behind a DELETE
 // (a create-with-same-name moments after deleting one 409'd here even though a GET already 404'd).

--- a/src/tools/apiKeys.ts
+++ b/src/tools/apiKeys.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Config } from "../config.js";
 import { iamListAll, iamRequest, withIamErrorHandling } from "../iamClient.js";
-import { toolJsonResult } from "../output.js";
+import { toolJsonResult, toolError } from "../output.js";
 
 interface ApiKey {
   access_key: string;
@@ -153,12 +153,27 @@ export function registerApiKeys(server: McpServer, config: Config) {
     "scaleway_iam_delete_api_key",
     {
       title: "Delete Scaleway API Key",
-      description: "PERMANENTLY revoke an API key by its access_key. Requires confirm=true. Irreversible - anything using this key stops authenticating immediately.",
+      description:
+        "PERMANENTLY revoke an API key by its access_key. Requires confirm=true. Irreversible - anything using this " +
+        "key stops authenticating immediately. Refused (even with confirm=true) when access_key is THIS server's " +
+        "own operating credential (SCW_ACCESS_KEY): deleting it would not just revoke one permission, it would " +
+        "revoke every capability this server has - IAM, S3, Audit Trail, all of it - immediately, with no way to " +
+        "undo it through this server (the credential needed to create a replacement is the one just deleted).",
       inputSchema: deleteSchema,
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     },
     async ({ access_key }) =>
       withIamErrorHandling(async () => {
+        if (access_key === config.SCW_ACCESS_KEY) {
+          return toolError(
+            `Refusing to delete ${access_key}: it is THIS server's own operating credential (SCW_ACCESS_KEY). ` +
+              "Deleting it would revoke every capability this server has, not just IAM management, and there is " +
+              "no way to undo it through this server afterward - the credential needed to create a replacement " +
+              "key is the one just deleted. This is refused even with confirm=true. Create a replacement key on " +
+              "the Application first (scaleway_iam_create_api_key), redeploy this server with it, and only then " +
+              "delete the old one.",
+          );
+        }
         await iamRequest<void>(config, "DELETE", `/api-keys/${access_key}`);
         return toolJsonResult({ deleted: true, access_key }, config.MAX_OUTPUT_CHARS);
       }),

--- a/src/tools/applications.ts
+++ b/src/tools/applications.ts
@@ -17,6 +17,11 @@ interface Application {
   tags?: string[];
 }
 
+/** Minimal shape needed to resolve which Application owns THIS server's own operating credential. */
+interface OwnApiKey {
+  application_id?: string;
+}
+
 const createSchema = {
   name: z
     .string()
@@ -154,12 +159,25 @@ export function registerApplications(server: McpServer, config: Config) {
         "Requires confirm=true. Refused (even with confirm=true) if a policy attached to this Application currently " +
         "grants IAMPolicyManager/IAMApplicationManager: deleting the Application DETACHES that policy rather than " +
         "deleting it, which would silently strip the IAM-management grant from whoever holds it - including this " +
-        "server, if this is its own Application - without ever going through scaleway_iam_delete_policy's own guard.",
+        "server, if this is its own Application - without ever going through scaleway_iam_delete_policy's own guard. " +
+        "Also refused outright if this IS the Application that owns THIS server's own operating credential " +
+        "(SCW_ACCESS_KEY), independent of the IAM-management check above: deleting it also deletes every API key " +
+        "it holds, including the one authenticating this very call, revoking every capability this server has - " +
+        "not just IAM - with no way to undo it afterward.",
       inputSchema: deleteSchema,
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     },
     async ({ application_id }) =>
       withIamErrorHandling(async () => {
+        const ownKey = await iamRequest<OwnApiKey>(config, "GET", `/api-keys/${config.SCW_ACCESS_KEY}`);
+        if (ownKey.application_id === application_id) {
+          return toolError(
+            `Refusing to delete ${application_id}: it is the Application that owns THIS server's own operating ` +
+              "credential (SCW_ACCESS_KEY). Deleting an Application deletes every API key it holds, including the " +
+              "one authenticating this very call - this server would lose every capability it has, not just IAM " +
+              "management, with no way to undo it afterward. This is refused even with confirm=true.",
+          );
+        }
         const blocking = await findIamManagementPoliciesFor(config, { application_id });
         if (blocking.length > 0) {
           return toolError(


### PR DESCRIPTION
## Summary

- `scaleway_iam_delete_api_key` and `scaleway_iam_delete_application` had no guard against deleting THIS server's own operating credential (`SCW_ACCESS_KEY`) or the Application that owns it. Unlike the #43 IAM-management lockout, this class of self-lockout revokes **every** capability the server has (IAM, S3, Audit Trail - all of it), immediately and irreversibly, with no recovery path through this server.
- `delete_api_key` now refuses outright (even with `confirm=true`) when `access_key === config.SCW_ACCESS_KEY`.
- `delete_application` now resolves the Application that owns `SCW_ACCESS_KEY` (`GET /api-keys/{access_key}`) and refuses a matching target, checked before the existing #43 IAM-management policy check.
- Both refusals mirror the existing pattern in this codebase (`delete_user`'s owner refusal, `delete_policy`/`delete_application`/`delete_group`'s IAM-management refusal): refused even with `confirm=true`, not just confirm-gated.

## Test plan

- [x] `npm run build` (tsc) passes clean
- [x] `node --check scripts/smoke-test.mjs` passes
- [x] Added smoke-test coverage: resolves the real operating key's `application_id` via `list_api_keys`, then calls `delete_api_key`/`delete_application` on the real operating credential/Application with `confirm: true` and asserts both are refused - proving the guard fires *before* any DELETE request reaches the API (same pattern already used for the real-OWNER `delete_user` guard in this suite)
- [ ] Live smoke test (`node scripts/smoke-test.mjs`) - **not run**, no live Scaleway credentials available in this environment. Verified via code review + build instead, per repo convention for this kind of change.

Closes #63
