### PR TITLE
chore: bump to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+## 0.2.0 (2026-08-20)
+
+Follow-up hardening pass after a multi-angle audit (static review of the full codebase plus live
+adversarial testing against a real account) found 17 real issues across three rounds - all fixed
+here. Several are schema changes that reject input the previous version silently accepted (new
+required `confirm` fields, stricter bucket-name/region validation), which is why this is a minor
+bump rather than a patch, per this project's pre-1.0 convention.
+
 - `scripts/smoke-test.mjs` now exercises the full `put`/`get`/`delete_bucket_policy` round trip on the throwaway config bucket - previously these tools had zero coverage in this suite (every other bucket-config feature in the same file gets this treatment), despite Bucket Policies being able to grant `Principal *` (#65).
 - `scaleway_s3_delete_bucket_encryption` now requires `confirm=true` and is annotated `destructiveHint: true`, matching its siblings `delete_bucket_tagging`/`delete_bucket_lifecycle`/`delete_bucket_policy` in the same file - it silently disables a live security control (future uploads stop getting default SSE), the same "loosening" class of change `scaleway_iam_update_security_settings` already requires `confirm=true` for (#64).
 - `scaleway_iam_delete_api_key` now refuses (even with `confirm=true`) to delete THIS server's own operating credential (the key matching `SCW_ACCESS_KEY`), and `scaleway_iam_delete_application` now refuses to delete the Application that owns it - deleting either would revoke every capability this server has (not just IAM management, the class of lockout #43 covers) with no way to undo it through this server afterward (#63).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scaleway-ops-mcp-server",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "MCP server for Scaleway IAM (Applications, API keys, Policies, Permission sets) and Object Storage (buckets, Bucket Policies, object CRUD)",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const config = loadConfig();
 
 const server = new McpServer({
   name: "scaleway-ops-mcp-server",
-  version: "0.1.0",
+  version: "0.2.0",
 });
 
 registerApplications(server, config);


### PR DESCRIPTION
## Summary
- Rolls the `## Unreleased` CHANGELOG section into a dated `0.2.0` entry - 17 fixes from the three-round audit (two static source reviews + live adversarial fuzz testing against a real account).
- Minor bump, not patch: several fixes are schema changes that reject input the previous version silently accepted (new required `confirm` fields on `set_policy_rules`/`put_bucket_policy`/tags-CORS-object-writes, stricter bucket-name/region validation) - a real, if narrow, breaking change per this project's pre-1.0 convention.
- Fixes `src/index.ts`'s `McpServer` version string, hardcoded at `"0.1.0"` since the initial commit and never bumped alongside `package.json` - found during the audit, fixed here while already touching this file.

## Test plan
- [x] `npm run build` passes clean, both version strings now read `0.2.0`
- [x] Verified via the real built server (`node dist/index.js` + a raw MCP `initialize` request) that it reports `serverInfo.version: "0.2.0"`
- [x] `npm pack --dry-run` confirms the tarball is still lean (78.6 kB / 397.6 kB unpacked)
- [ ] `npm publish` is a separate, deliberate step after this merges (needs the maintainer's npm credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)