### PR TITLE
docs: pin npx config to @latest (live-verified stale-cache bug)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,19 @@ Application scoped for something else) and grant it only what the table above ne
 
 ## Running
 
-Via Claude Code / any MCP client, as a stdio server. Simplest, via `npx` (no local clone needed):
+Via Claude Code / any MCP client, as a stdio server. Simplest, via `npx` (no local clone needed) -
+pin `@latest` explicitly, don't leave the spec bare: `npx` caches its first resolution of an
+unpinned package name and silently keeps reusing that same version on every later run, even after
+a new one is published, unless you either pin `@latest` or clear `npx`'s cache yourself
+(live-verified 2026-08-20 - `npx -y scaleway-ops-mcp-server` kept serving a stale `0.1.0` from
+days earlier while `npx -y scaleway-ops-mcp-server@latest` correctly resolved `0.2.0`):
 
 ```json
 {
   "mcpServers": {
     "scaleway-ops": {
       "command": "npx",
-      "args": ["-y", "scaleway-ops-mcp-server"],
+      "args": ["-y", "scaleway-ops-mcp-server@latest"],
       "env": {
         "SCW_ACCESS_KEY": "...",
         "SCW_SECRET_KEY": "...",


### PR DESCRIPTION
## Summary
Tested \`npx -y scaleway-ops-mcp-server\` against the real published package today, after the v0.2.0 release: it silently served a cached \`0.1.0\` resolution from two days ago (my own first test run, before 0.1.1/0.2.0 existed) instead of the current \`0.2.0\` - no warning, no version-check output, just a stale server. \`npx -y scaleway-ops-mcp-server@latest\` correctly resolved to \`0.2.0\`.

Root cause: \`npx\` caches its first resolution of an unpinned package spec (keyed under \`~/.npm/_npx/<hash>\` on this machine) and reuses it on every subsequent invocation of that same bare spec, regardless of what's newly published, unless the caller pins a version/tag or clears the cache.

The README's own example config used the unpinned form. Anyone who copied it into their MCP client config before today's releases would keep silently running \`0.1.0\` forever through that same config - never picking up any of the security/safety fixes in 0.1.1/0.2.0.

## Fix
Pin \`@latest\` in the example config, with a short explanation of why - forces npx to re-check the registry each run instead of trusting a cached resolution.

## Test plan
- [x] Live-verified against the real npm package: unpinned \`npx -y scaleway-ops-mcp-server\` served cached \`0.1.0\`; \`npx -y scaleway-ops-mcp-server@latest\` correctly served \`0.2.0\` (both checked via a raw MCP \`initialize\` call inspecting \`serverInfo.version\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)